### PR TITLE
nr/base object

### DIFF
--- a/.github/workflows/selftest.yaml
+++ b/.github/workflows/selftest.yaml
@@ -1,0 +1,25 @@
+# This workflow is used to validate if the current version of kraken-core and kraken-std work without
+# errors to build the kraken-std project. When some larger changes are being made to these two components,
+# such as one that causes a breaking API change for the kraken-std build script, this workflow may need
+# to be temporarily disabled.
+
+name: "Selftest"
+
+on:
+  push: { branches: [ "develop" ], tags: [ "*" ] }
+  pull_request: { branches: [ "develop" ] }
+
+jobs:
+  kraken-std-selftest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: NiklasRosenstein/slap@gha/install/v1
+    - uses: actions/setup-python@v2
+      with: { python-version: "3.10" }
+    - run: slap install --link --no-venv-check ${{ matrix.only }}
+    - run: cd kraken-std && kraken run fmt lint test -vv
+    - run: cd kraken-std && kraken q ls
+    - run: cd kraken-std && kraken q tree
+    - run: cd kraken-std && kraken q viz
+    - run: cd kraken-std && kraken q d python.mypy

--- a/kraken-core/.changelog/_unreleased.toml
+++ b/kraken-core/.changelog/_unreleased.toml
@@ -9,3 +9,15 @@ id = "65c94c4b-1dd5-43b8-ae97-d911b860113d"
 type = "breaking change"
 description = "Change `Addressable.address` into a read-only property"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "400b123c-093c-486a-8c1c-c70889bf6eac"
+type = "improvement"
+description = "Make `Project` a subclass of the new `KrakenObject` class"
+author = "@NiklasRosenstein"
+
+[[entries]]
+id = "02f2d93b-232f-4471-8d9e-dfe05bc92ee5"
+type = "deprecation"
+description = "Deprecate `Project.path` and `Project.resolve_tasks()`"
+author = "@NiklasRosenstein"

--- a/kraken-core/.changelog/_unreleased.toml
+++ b/kraken-core/.changelog/_unreleased.toml
@@ -3,51 +3,60 @@ id = "c74b81bf-e59a-4b7a-9dbc-be571bb8cb88"
 type = "breaking change"
 description = "Remove deprecated `Project.children()` method and deprecated `Project.subproject()` overloads."
 author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken-build/pull/44"
 
 [[entries]]
 id = "65c94c4b-1dd5-43b8-ae97-d911b860113d"
 type = "breaking change"
 description = "Change `Addressable.address` into a read-only property"
 author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken-build/pull/44"
 
 [[entries]]
 id = "400b123c-093c-486a-8c1c-c70889bf6eac"
 type = "improvement"
 description = "Make `Project` a subclass of the new `KrakenObject` class"
 author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken-build/pull/44"
 
 [[entries]]
 id = "02f2d93b-232f-4471-8d9e-dfe05bc92ee5"
 type = "deprecation"
 description = "Deprecate `Project.path` and `Project.resolve_tasks()`"
 author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken-build/pull/44"
 
 [[entries]]
 id = "8ab2ec4c-9776-47f1-a234-0ba0832a7e09"
 type = "deprecation"
 description = "Deprecated `Task.outputs`, `Task.path` and `Task.add_relationship()`"
 author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken-build/pull/44"
 
 [[entries]]
 id = "f31e8357-54c5-4904-b62a-6786be13dc22"
 type = "breaking change"
 description = "Remove `Task.capture`"
 author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken-build/pull/44"
 
 [[entries]]
 id = "a56aa4ad-e789-41ca-b42d-0f404337f88b"
 type = "feature"
 description = "Add `Task.depends_on()` and `Task.required_by()`"
 author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken-build/pull/44"
 
 [[entries]]
 id = "1c72b74e-6188-4e95-b02a-b92612278d2c"
 type = "fix"
 description = "Move `Address.Element` class definition to the global scope, as otherwise we run into an issue with Dill deserialization where the type of `Address.elements` items is not actually the `Address.Element` type that we can access at runtime. (See https://github.com/uqfoundation/dill/issues/600)."
 author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken-build/pull/44"
 
 [[entries]]
 id = "268ab1d2-4010-4db9-b5a2-9e2d7478fc92"
 type = "breaking change"
 description = "`TaskGraph` implementation now stores `Address` keys instead of strings"
 author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken-build/pull/44"

--- a/kraken-core/.changelog/_unreleased.toml
+++ b/kraken-core/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "c74b81bf-e59a-4b7a-9dbc-be571bb8cb88"
 type = "breaking change"
 description = "Remove deprecated `Project.children()` method and deprecated `Project.subproject()` overloads."
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "65c94c4b-1dd5-43b8-ae97-d911b860113d"
+type = "breaking change"
+description = "Change `Addressable.address` into a read-only property"
+author = "@NiklasRosenstein"

--- a/kraken-core/.changelog/_unreleased.toml
+++ b/kraken-core/.changelog/_unreleased.toml
@@ -45,3 +45,9 @@ id = "1c72b74e-6188-4e95-b02a-b92612278d2c"
 type = "fix"
 description = "Move `Address.Element` class definition to the global scope, as otherwise we run into an issue with Dill deserialization where the type of `Address.elements` items is not actually the `Address.Element` type that we can access at runtime. (See https://github.com/uqfoundation/dill/issues/600)."
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "268ab1d2-4010-4db9-b5a2-9e2d7478fc92"
+type = "breaking change"
+description = "`TaskGraph` implementation now stores `Address` keys instead of strings"
+author = "@NiklasRosenstein"

--- a/kraken-core/.changelog/_unreleased.toml
+++ b/kraken-core/.changelog/_unreleased.toml
@@ -39,3 +39,9 @@ id = "a56aa4ad-e789-41ca-b42d-0f404337f88b"
 type = "feature"
 description = "Add `Task.depends_on()` and `Task.required_by()`"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "1c72b74e-6188-4e95-b02a-b92612278d2c"
+type = "fix"
+description = "Move `Address.Element` class definition to the global scope, as otherwise we run into an issue with Dill deserialization where the type of `Address.elements` items is not actually the `Address.Element` type that we can access at runtime. (See https://github.com/uqfoundation/dill/issues/600)."
+author = "@NiklasRosenstein"

--- a/kraken-core/.changelog/_unreleased.toml
+++ b/kraken-core/.changelog/_unreleased.toml
@@ -21,3 +21,21 @@ id = "02f2d93b-232f-4471-8d9e-dfe05bc92ee5"
 type = "deprecation"
 description = "Deprecate `Project.path` and `Project.resolve_tasks()`"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "8ab2ec4c-9776-47f1-a234-0ba0832a7e09"
+type = "deprecation"
+description = "Deprecated `Task.outputs`, `Task.path` and `Task.add_relationship()`"
+author = "@NiklasRosenstein"
+
+[[entries]]
+id = "f31e8357-54c5-4904-b62a-6786be13dc22"
+type = "breaking change"
+description = "Remove `Task.capture`"
+author = "@NiklasRosenstein"
+
+[[entries]]
+id = "a56aa4ad-e789-41ca-b42d-0f404337f88b"
+type = "feature"
+description = "Add `Task.depends_on()` and `Task.required_by()`"
+author = "@NiklasRosenstein"

--- a/kraken-core/.changelog/_unreleased.toml
+++ b/kraken-core/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "c74b81bf-e59a-4b7a-9dbc-be571bb8cb88"
+type = "breaking change"
+description = "Remove deprecated `Project.children()` method and deprecated `Project.subproject()` overloads."
+author = "@NiklasRosenstein"

--- a/kraken-core/src/kraken/core/address/_addressable.py
+++ b/kraken-core/src/kraken/core/address/_addressable.py
@@ -10,5 +10,6 @@ class Addressable(Protocol):
     address of any such object is expected to be concrete (see #Address.is_concrete()).
     """
 
-    #: The concrete address of the object.
-    address: Address
+    @property
+    def address(self) -> Address:
+        raise NotImplementedError

--- a/kraken-core/src/kraken/core/cli/main.py
+++ b/kraken-core/src/kraken/core/cli/main.py
@@ -515,7 +515,6 @@ def describe(graph: TaskGraph) -> None:
         print("  Type defined in:", colored(sys.modules[type(task).__module__].__file__ or "???", "cyan"))
         print("  Default:", task.default)
         print("  Selected:", task.selected)
-        print("  Capture:", task.capture)
         rels = list(task.get_relationships())
         print(colored("  Relationships", attrs=["bold"]), f"({len(rels)})")
         for rel in rels:

--- a/kraken-core/src/kraken/core/lib/render_file_task.py
+++ b/kraken-core/src/kraken/core/lib/render_file_task.py
@@ -46,7 +46,7 @@ class RenderFileTask(Task):
             encoding=self.encoding.value,
             render_prepare=Supplier.of_callable(self.prepare),
         )
-        task.add_relationship(self, strict=False)
+        task.depends_on(self, mode="order-only")
         return task
 
     # Task

--- a/kraken-core/src/kraken/core/system/context.py
+++ b/kraken-core/src/kraken/core/system/context.py
@@ -204,7 +204,7 @@ class Context(MetadataContainer, Currentable["Context"]):
         assert project is not None
 
         for element in address.elements:
-            project = project.subproject(element.value, load=False)
+            project = project.subproject(element.value, "if-exists")
             if not project:
                 raise ProjectNotFoundError(address)
 

--- a/kraken-core/src/kraken/core/system/executor/__init__.py
+++ b/kraken-core/src/kraken/core/system/executor/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import abc
 from typing import TYPE_CHECKING, Iterator
 
+from kraken.core.address import Address
+
 if TYPE_CHECKING:
     from kraken.core.system.task import Task, TaskStatus
 
@@ -22,7 +24,7 @@ class Graph(abc.ABC):
         """Return all active dependants of the given task."""
 
     @abc.abstractmethod
-    def get_task(self, task_path: str) -> Task:
+    def get_task(self, task_path: Address) -> Task:
         """Return a task by its path."""
 
     @abc.abstractmethod

--- a/kraken-core/src/kraken/core/system/executor/default_test.py
+++ b/kraken-core/src/kraken/core/system/executor/default_test.py
@@ -77,9 +77,9 @@ def test__DefaultExecutor__print_correct_failures_with_dependencies(
     task_c = kraken_project.do("fake_task_c", MyTask)
     task_d = kraken_project.do("fake_task_d", MyTask)
 
-    task_b.add_relationship(task_a)
-    task_c.add_relationship(task_b)
-    task_d.add_relationship(task_c)
+    task_b.depends_on(task_a)
+    task_c.depends_on(task_b)
+    task_d.depends_on(task_c)
 
     graph = TaskGraph(kraken_project.context).trim([task_d])
     assert set(graph.tasks()) == {task_a, task_b, task_c, task_d}
@@ -140,9 +140,9 @@ def test__DefaultExecutor__print_correct_failures_inside_group_with_dependency(
 
     group = kraken_project.group("group")
 
-    task_b.add_relationship(task_a)
-    task_c.add_relationship(task_b)
-    task_d.add_relationship(task_b)
+    task_b.depends_on(task_a)
+    task_c.depends_on(task_b)
+    task_d.depends_on(task_b)
 
     graph = TaskGraph(kraken_project.context).trim([group])
     execute_print_test(graph)
@@ -180,10 +180,10 @@ def test__DefaultExecutor__print_correct_failures_with_independent_groups(
     g1 = kraken_project.group("g1")
     g2 = kraken_project.group("g2")
 
-    task_b.add_relationship(task_a)
-    task_c.add_relationship(task_b)
-    task_e.add_relationship(task_d)
-    task_f.add_relationship(task_e)
+    task_b.depends_on(task_a)
+    task_c.depends_on(task_b)
+    task_e.depends_on(task_d)
+    task_f.depends_on(task_e)
 
     graph = TaskGraph(kraken_project.context).trim([g1, g2])
     execute_print_test(graph)
@@ -224,12 +224,12 @@ def test__DefaultExecutor__print_correct_failures_with_dependent_groups(
     g1 = kraken_project.group("g1")
     g2 = kraken_project.group("g2")
 
-    task_b.add_relationship(task_a)
-    task_c.add_relationship(task_b)
-    task_e.add_relationship(task_d)
-    task_f.add_relationship(task_e)
+    task_b.depends_on(task_a)
+    task_c.depends_on(task_b)
+    task_e.depends_on(task_d)
+    task_f.depends_on(task_e)
 
-    g2.add_relationship(g1)
+    g2.depends_on(g1)
 
     graph = TaskGraph(kraken_project.context).trim([g2])
     execute_print_test(graph)

--- a/kraken-core/src/kraken/core/system/graph.py
+++ b/kraken-core/src/kraken/core/system/graph.py
@@ -9,6 +9,7 @@ from networkx import DiGraph, restricted_view, transitive_reduction
 from networkx.algorithms import topological_sort
 from nr.stream import Stream
 
+from kraken.core.address import Address
 from kraken.core.system.executor import Graph
 from kraken.core.system.task import GroupTask, Task, TaskStatus
 
@@ -46,18 +47,18 @@ class TaskGraph(Graph):
         self._digraph = DiGraph()
 
         # Keep track of task execution results.
-        self._results: dict[str, TaskStatus] = {}
+        self._results: dict[Address, TaskStatus] = {}
 
         # All tasks that have a successful or skipped status are stored here.
-        self._ok_tasks: set[str] = set()
+        self._ok_tasks: set[Address] = set()
 
         # All tasks that have a failed status are stored here.
-        self._failed_tasks: set[str] = set()
+        self._failed_tasks: set[Address] = set()
 
         # Keep track of the tasks that returned TaskStatus.STARTED. That means the task is a background task, and
         # if the TaskGraph is deserialized from a state file to continue the build, background tasks need to be
         # reset so they start again if another task requires them.
-        self._background_tasks: set[str] = set()
+        self._background_tasks: set[Address] = set()
 
         if populate:
             self.populate()
@@ -70,22 +71,23 @@ class TaskGraph(Graph):
 
     # Low level internal API
 
-    def _get_task(self, task_path: str) -> Task | None:
-        data = self._digraph.nodes.get(task_path)
+    def _get_task(self, addr: Address) -> Task | None:
+        assert isinstance(addr, Address), type(addr)
+        data = self._digraph.nodes.get(addr)
         if data is None:
             return None
         try:
             return cast(Task, data["data"])
         except KeyError:
-            raise RuntimeError(f"An unexpected error occurred when fetching the task by address {task_path!r}.")
+            raise RuntimeError(f"An unexpected error occurred when fetching the task by address {addr!r}.")
 
     def _add_task(self, task: Task) -> None:
-        self._digraph.add_node(task.path, data=task)
+        self._digraph.add_node(task.address, data=task)
         for rel in task.get_relationships():
-            if rel.other_task.path not in self._digraph.nodes:
+            if rel.other_task.address not in self._digraph.nodes:
                 self._add_task(rel.other_task)
             a, b = (task, rel.other_task) if rel.inverse else (rel.other_task, task)
-            self._add_edge(a.path, b.path, rel.strict, False)
+            self._add_edge(a.address, b.address, rel.strict, False)
 
             # If this relationship is one implied through group membership, we're done.
             if isinstance(task, GroupTask) and not rel.inverse and rel.other_task in task.tasks:
@@ -98,7 +100,7 @@ class TaskGraph(Graph):
                 downstream_tasks = list(downstream.tasks)
                 while downstream_tasks:
                     member = downstream_tasks.pop(0)
-                    if member.path not in self._digraph.nodes:
+                    if member.address not in self._digraph.nodes:
                         self._add_task(member)
                     if isinstance(member, GroupTask):
                         downstream_tasks += member.tasks
@@ -107,15 +109,15 @@ class TaskGraph(Graph):
                     # NOTE(niklas.rosenstein): When a group is nested in another group, we would end up declaring
                     #       that the group depends on itself. That's obviously not supposed to happen. :)
                     if upstream != member:
-                        self._add_edge(upstream.path, member.path, rel.strict, True)
+                        self._add_edge(upstream.address, member.address, rel.strict, True)
 
-    def _get_edge(self, task_a: str, task_b: str) -> _Edge | None:
+    def _get_edge(self, task_a: Address, task_b: Address) -> _Edge | None:
         data = self._digraph.edges.get((task_a, task_b)) or self._digraph.edges.get((task_a, task_b))
         if data is None:
             return None
         return cast(_Edge, data["data"])
 
-    def _add_edge(self, task_a: str, task_b: str, strict: bool, implicit: bool) -> None:
+    def _add_edge(self, task_a: Address, task_b: Address, strict: bool, implicit: bool) -> None:
         # add_edge() would implicitly add a node, we only want to do that once the node actually exists in
         # the graph though.
         assert task_a in self._digraph.nodes, f"{task_a!r} not yet in the graph"
@@ -127,43 +129,43 @@ class TaskGraph(Graph):
 
     # High level internal API
 
-    def _get_required_tasks(self, goals: Iterable[Task]) -> set[str]:
+    def _get_required_tasks(self, goals: Iterable[Task]) -> set[Address]:
         """Internal. Return the set of tasks that are required transitively from the goal tasks."""
 
-        def _is_empty_group_subtree(task_path: str) -> bool:
+        def _is_empty_group_subtree(addr: Address) -> bool:
             """
-            Returns `True` if the task pointed to by *task_path* is a GroupTask and it is empty or only depends on
+            Returns `True` if the task pointed to by *addr* is a GroupTask and it is empty or only depends on
             other empty groups.
             """
 
-            def _is_empty_group(task_path: str) -> bool:
-                """Returns `True` if the task pointed to by *task_path* is a GroupTask and it is empty."""
+            def _is_empty_group(addr: Address) -> bool:
+                """Returns `True` if the task pointed to by *addr* is a GroupTask and it is empty."""
 
-                task = self._get_task(task_path)
+                task = self._get_task(addr)
                 if not isinstance(task, GroupTask):
                     return False
                 return len(task.tasks) == 0
 
-            def _is_empty_group_or_subtree(task_path: str) -> bool:
-                """Returns `True` if the task pointed to by *task_path* is a GroupTask and it is empty or only depends
+            def _is_empty_group_or_subtree(addr: Address) -> bool:
+                """Returns `True` if the task pointed to by *addr* is a GroupTask and it is empty or only depends
                 on other empty groups."""
 
-                task = self._get_task(task_path)
+                task = self._get_task(addr)
                 if not isinstance(task, GroupTask):
                     return False
-                for pred in self._digraph.predecessors(task_path):
+                for pred in self._digraph.predecessors(addr):
                     if not _is_empty_group_or_subtree(pred):
                         return False
                 return True
 
-            return _is_empty_group(task_path) or _is_empty_group_or_subtree(task_path)
+            return _is_empty_group(addr) or _is_empty_group_or_subtree(addr)
 
-        def _recurse_task(task_path: str, visited: set[str], path: list[str]) -> None:
-            if task_path in path:
-                raise RuntimeError(f"encountered a dependency cycle: {' → '.join(path)}")
-            visited.add(task_path)
-            for pred in self._digraph.predecessors(task_path):
-                if not_none(self._get_edge(pred, task_path)).strict:
+        def _recurse_task(addr: Address, visited: set[Address], path: list[Address]) -> None:
+            if addr in path:
+                raise RuntimeError(f"encountered a dependency cycle: {' → '.join(map(str, path))}")
+            visited.add(addr)
+            for pred in self._digraph.predecessors(addr):
+                if not_none(self._get_edge(pred, addr)).strict:
                     # If the thing we want to pick up is a GroupTask and it doesn't have any members or other
                     # dependencies that are not also empty groups, we can skip it. It really doesn't need to be in the
                     # build graph.
@@ -171,37 +173,37 @@ class TaskGraph(Graph):
                         # Check if the group is empty or only depends on other empty groups.
                         if _is_empty_group_subtree(pred):
                             continue
-                    _recurse_task(pred, visited, path + [task_path])
+                    _recurse_task(pred, visited, path + [addr])
 
-        active_tasks: set[str] = set()
+        active_tasks: set[Address] = set()
         for task in goals:
-            _recurse_task(task.path, active_tasks, [])
+            _recurse_task(task.address, active_tasks, [])
 
         return active_tasks
 
-    def _remove_nodes_keep_transitive_edges(self, nodes: Iterable[str]) -> None:
+    def _remove_nodes_keep_transitive_edges(self, nodes: Iterable[Address]) -> None:
         """Internal. Remove nodes from the graph, but ensure that transitive dependencies are kept in tact."""
 
-        for task_path in nodes:
-            for in_task_path in self._digraph.predecessors(task_path):
-                in_edge = not_none(self._get_edge(in_task_path, task_path))
-                for out_task_path in self._digraph.successors(task_path):
-                    out_edge = not_none(self._get_edge(task_path, out_task_path))
+        for addr in nodes:
+            for in_task_path in self._digraph.predecessors(addr):
+                in_edge = not_none(self._get_edge(in_task_path, addr))
+                for out_task_path in self._digraph.successors(addr):
+                    out_edge = not_none(self._get_edge(addr, out_task_path))
                     self._add_edge(
                         in_task_path,
                         out_task_path,
                         strict=in_edge.strict or out_edge.strict,
                         implicit=in_edge.implicit and out_edge.implicit,
                     )
-            self._digraph.remove_node(task_path)
+            self._digraph.remove_node(addr)
 
     def _get_ready_graph(self) -> DiGraph:
         """Updates the ready graph. Remove all ok tasks (successful or skipped) and any non-strict dependencies
         (edges) on failed tasks."""
 
-        removable_edges: set[tuple[str, str]] = set()
+        removable_edges: set[tuple[Address, Address]] = set()
 
-        def set_non_strict_edge_for_removal(u: str, v: str) -> None:
+        def set_non_strict_edge_for_removal(u: Address, v: Address) -> None:
             out_edge = not_none(self._get_edge(u, v))
             if not out_edge.strict:
                 removable_edges.add((u, v))
@@ -213,7 +215,7 @@ class TaskGraph(Graph):
                 if isinstance(out_task, GroupTask):
                     # If the successor is a group task, check that the all of the groups tasks are either successful
                     # or failed, and then remove any non strict dependency (edge) on said group task.
-                    group_task_paths = {task.path for task in out_task.tasks}
+                    group_task_paths = {task.address for task in out_task.tasks}
                     if not group_task_paths.issubset(self._failed_tasks | self._ok_tasks):
                         continue
 
@@ -241,13 +243,15 @@ class TaskGraph(Graph):
         return self
 
     def get_edge(self, pred: Task, succ: Task) -> _Edge:
-        return not_none(self._get_edge(pred.path, succ.path), f"edge does not exist ({pred.path} --> {succ.path})")
+        return not_none(
+            self._get_edge(pred.address, succ.address), f"edge does not exist ({pred.address} --> {succ.address})"
+        )
 
     def get_predecessors(self, task: Task, ignore_groups: bool = False) -> List[Task]:
         """Returns the predecessors of the task in the original full build graph."""
 
         result = []
-        for task in (not_none(self._get_task(task_path)) for task_path in self._digraph.predecessors(task.path)):
+        for task in (not_none(self._get_task(addr)) for addr in self._digraph.predecessors(task.address)):
             if ignore_groups and isinstance(task, GroupTask):
                 result += task.tasks
             else:
@@ -257,7 +261,7 @@ class TaskGraph(Graph):
     def get_status(self, task: Task) -> TaskStatus | None:
         """Return the status of a task."""
 
-        return self._results.get(task.path)
+        return self._results.get(task.address)
 
     def populate(self, goals: Iterable[Task] | None = None) -> None:
         """Populate the graph with the tasks from the context. This need only be called if the graph was
@@ -273,11 +277,11 @@ class TaskGraph(Graph):
         if goals is None:
             for project in self.context.iter_projects():
                 for task in project.tasks().values():
-                    if task.path not in self._digraph.nodes:
+                    if task.address not in self._digraph.nodes:
                         self._add_task(task)
         else:
             for task in goals:
-                if task.path not in self._digraph.nodes:
+                if task.address not in self._digraph.nodes:
                     self._add_task(task)
 
     def trim(self, goals: Sequence[Task]) -> TaskGraph:
@@ -319,8 +323,8 @@ class TaskGraph(Graph):
         self._failed_tasks.update(other._failed_tasks)
 
         for task in self.tasks():
-            status_a = self._results.get(task.path)
-            status_b = other._results.get(task.path)
+            status_a = self._results.get(task.address)
+            status_b = other._results.get(task.address)
             if status_a is not None and status_b is not None and status_a.type != status_b.type:
                 resolved_status: TaskStatus | None = status_a if status_a.is_not_ok() else status_b
             else:
@@ -334,18 +338,20 @@ class TaskGraph(Graph):
         called when a build graph is resumed in a secondary execution to ensure that background tasks are active
         for the tasks that require them."""
 
-        reset_tasks: set[str] = set()
+        reset_tasks: set[Address] = set()
         for task in self.tasks(pending=True):
             for pred in self.get_predecessors(task, ignore_groups=True):
-                if pred.path in self._background_tasks:
-                    self._background_tasks.discard(pred.path)
-                    self._ok_tasks.discard(pred.path)
-                    self._failed_tasks.discard(pred.path)
-                    self._results.pop(pred.path, None)
-                    reset_tasks.add(pred.path)
+                if pred.address in self._background_tasks:
+                    self._background_tasks.discard(pred.address)
+                    self._ok_tasks.discard(pred.address)
+                    self._failed_tasks.discard(pred.address)
+                    self._results.pop(pred.address, None)
+                    reset_tasks.add(pred.address)
 
         if reset_tasks:
-            logger.info("Reset the status of %d background task(s): %s", len(reset_tasks), " ".join(reset_tasks))
+            logger.info(
+                "Reset the status of %d background task(s): %s", len(reset_tasks), " ".join(map(str, reset_tasks))
+            )
 
     def restart(self) -> None:
         """Discard the results of all tasks."""
@@ -369,25 +375,25 @@ class TaskGraph(Graph):
         :param failed: Return only failed tasks.
         :param not_executed: Return only not executed tasks (i.e. downstream of failed tasks)"""
 
-        tasks = (not_none(self._get_task(task_path)) for task_path in self._digraph)
+        tasks = (not_none(self._get_task(addr)) for addr in self._digraph)
         if goals:
-            tasks = (t for t in tasks if self._digraph.out_degree(t.path) == 0)
+            tasks = (t for t in tasks if self._digraph.out_degree(t.address) == 0)
         if pending:
-            tasks = (t for t in tasks if t.path not in self._results)
+            tasks = (t for t in tasks if t.address not in self._results)
         if failed:
-            tasks = (t for t in tasks if t.path in self._results and self._results[t.path].is_failed())
+            tasks = (t for t in tasks if t.address in self._results and self._results[t.address].is_failed())
         if not_executed:
             tasks = (
                 t
                 for t in tasks
                 if (
-                    (t.path not in self._results)
+                    (t.address not in self._results)
                     or (
-                        t.path in self._results
-                        and not self._results[t.path].is_succeeded()
-                        and not self._results[t.path].is_failed()
-                        and not self._results[t.path].is_skipped()
-                        and not self._results[t.path].is_up_to_date()
+                        t.address in self._results
+                        and not self._results[t.address].is_succeeded()
+                        and not self._results[t.address].is_failed()
+                        and not self._results[t.address].is_skipped()
+                        and not self._results[t.address].is_up_to_date()
                     )
                 )
             )
@@ -399,7 +405,7 @@ class TaskGraph(Graph):
         :param all: Return the execution order of all tasks, not just from the target subgraph."""
 
         order = topological_sort(self._digraph if all else self._get_ready_graph())
-        return (not_none(self._get_task(task_path)) for task_path in order)
+        return (not_none(self._get_task(addr)) for addr in order)
 
     # Graph
 
@@ -413,7 +419,7 @@ class TaskGraph(Graph):
         root_set = (
             node for node in ready_graph.nodes if ready_graph.in_degree(node) == 0 and node not in self._results
         )
-        tasks = [not_none(self._get_task(task_path)) for task_path in root_set]
+        tasks = [not_none(self._get_task(addr)) for addr in root_set]
         if not tasks:
             return []
 
@@ -433,30 +439,32 @@ class TaskGraph(Graph):
         Never returns group tasks."""
 
         result = []
-        for task in (not_none(self._get_task(task_path)) for task_path in self._digraph.successors(task.path)):
+        for task in (not_none(self._get_task(addr)) for addr in self._digraph.successors(task.address)):
             if ignore_groups and isinstance(task, GroupTask):
                 result += task.tasks
             else:
                 result.append(task)
         return result
 
-    def get_task(self, task_path: str) -> Task:
+    def get_task(self, addr: Address | str) -> Task:
+        if isinstance(addr, str):
+            addr = Address(addr)
         if self._parent is None:
-            return not_none(self._get_task(task_path))
-        return self.root.get_task(task_path)
+            return not_none(self._get_task(addr))
+        return self.root.get_task(addr)
 
     def set_status(self, task: Task, status: TaskStatus, *, _force: bool = False) -> None:
         """Sets the status of a task, marking it as executed."""
 
-        if not _force and (task.path in self._results and not self._results[task.path].is_started()):
-            raise RuntimeError(f"already have a status for task {task.path!r}")
-        self._results[task.path] = status
+        if not _force and (task.address in self._results and not self._results[task.address].is_started()):
+            raise RuntimeError(f"already have a status for task `{task.address}`")
+        self._results[task.address] = status
         if status.is_started():
-            self._background_tasks.add(task.path)
+            self._background_tasks.add(task.address)
         if status.is_ok():
-            self._ok_tasks.add(task.path)
+            self._ok_tasks.add(task.address)
         if status.is_failed():
-            self._failed_tasks.add(task.path)
+            self._failed_tasks.add(task.address)
 
     def is_complete(self) -> bool:
         """Returns `True` if, an only if, all tasks in the target subgraph have a non-failure result."""

--- a/kraken-core/src/kraken/core/system/kraken_object.py
+++ b/kraken-core/src/kraken/core/system/kraken_object.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from kraken.common import NotSet
-
 from kraken.core.address import Address, Addressable
-from kraken.core.system.property import PropertyContainer
 
 
 class KrakenObject(Addressable):
@@ -28,7 +25,7 @@ class KrakenObject(Addressable):
         return self._name
 
     @property
-    def address(self) -> Address:  # type: ignore[override]
+    def address(self) -> Address:
         """
         Returns the full address of the object.
         """

--- a/kraken-core/src/kraken/core/system/kraken_object.py
+++ b/kraken-core/src/kraken/core/system/kraken_object.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from kraken.common import NotSet
+
+from kraken.core.address import Address, Addressable
+from kraken.core.system.property import PropertyContainer
+
+
+class KrakenObject(Addressable):
+    """
+    A Kraken object is an object that can be addressed in a Kraken context.
+    """
+
+    _name: str
+    _parent: KrakenObject | None
+
+    def __init__(self, name: str, parent: KrakenObject | None = None):
+        assert isinstance(name, str), type(name)
+        assert isinstance(parent, KrakenObject), type(parent)
+        self._name = name
+        self._parent = parent
+
+        # Validate that the name is valid by getting the object's address.
+        self.address
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def address(self) -> Address:  # type: ignore[override]
+        """
+        Returns the full address of the object.
+        """
+
+        if self._parent is None:
+            return Address.ROOT
+        else:
+            return self._parent.address.append(self._name)

--- a/kraken-core/src/kraken/core/system/kraken_object.py
+++ b/kraken-core/src/kraken/core/system/kraken_object.py
@@ -16,7 +16,7 @@ class KrakenObject(Addressable):
 
     def __init__(self, name: str, parent: KrakenObject | None = None):
         assert isinstance(name, str), type(name)
-        assert isinstance(parent, KrakenObject), type(parent)
+        assert isinstance(parent, KrakenObject) or parent is None, type(parent)
         self._name = name
         self._parent = parent
 

--- a/kraken-core/src/kraken/core/system/project.py
+++ b/kraken-core/src/kraken/core/system/project.py
@@ -121,10 +121,6 @@ class Project(MetadataContainer, Currentable["Project"]):
     def tasks(self) -> Mapping[str, Task]:
         return {t.name: t for t in self._members.values() if isinstance(t, Task)}
 
-    @deprecated(reason="use Project.subprojects() or Project.subproject() instead")
-    def children(self) -> Mapping[str, Project]:
-        return self.subprojects()
-
     def subprojects(self) -> Mapping[str, Project]:
         return {p.name: p for p in self._members.values() if isinstance(p, Project)}
 
@@ -151,35 +147,12 @@ class Project(MetadataContainer, Currentable["Project"]):
         #subproject() again with the *mode* set to "empty".
         """
 
-    @overload
-    @deprecated(reason="use the Project.subproject(mode) parameter instead")
-    def subproject(self, name: str, mode: bool) -> Project | None:
-        """
-        This is a deprecated version that is semantically equivalent to calling #subproject() with the *mode*
-        parameter set to "if-exists".
-        """
-
-    @overload
-    @deprecated(reason="use the Project.subproject(mode) parameter instead")
-    def subproject(self, name: str, *, load: bool) -> Project | None:
-        """
-        This is a deprecated version that is semantically equivalent to calling #subproject() with the *mode*
-        parameter set to "if-exists".
-        """
-
     def subproject(
         self,
         name: str,
-        mode: bool | Literal["empty", "execute", "if-exists"] = "execute",
-        *,
-        load: bool | None = None,
+        mode: Literal["empty", "execute", "if-exists"] = "execute",
     ) -> Project | None:
-        if load is not None:
-            warnings.warn("the `load` parameter is deprecated, use `mode` instead", DeprecationWarning)
-        if isinstance(mode, bool):
-            warnings.warn("the `load` parameter is deprecated, use `mode` instead", DeprecationWarning)
-            mode = "execute" if mode else "if-exists"
-        del load
+        assert isinstance(mode, str), f"mode must be a string, got {type(mode).__name__}"
 
         obj = self._members.get(name)
         if obj is None and mode == "if-exists":

--- a/kraken-core/src/kraken/core/system/project.py
+++ b/kraken-core/src/kraken/core/system/project.py
@@ -49,38 +49,38 @@ class Project(KrakenObject, MetadataContainer, Currentable["Project"]):
             "apply", description="Tasks that perform automatic updates to the project consistency."
         )
         fmt_group = self.group("fmt", description="Tasks that that perform code formatting operations.")
-        fmt_group.add_relationship(apply_group, strict=True)
+        fmt_group.depends_on(apply_group, mode="strict")
 
         check_group = self.group("check", description="Tasks that perform project consistency checks.", default=True)
 
         gen_group = self.group("gen", description="Tasks that perform code generation.", default=True)
 
         lint_group = self.group("lint", description="Tasks that perform code linting.", default=True)
-        lint_group.add_relationship(check_group, strict=True)
-        lint_group.add_relationship(gen_group, strict=True)
+        lint_group.depends_on(check_group, mode="strict")
+        lint_group.depends_on(gen_group, mode="strict")
 
         build_group = self.group("build", description="Tasks that produce build artefacts.")
-        build_group.add_relationship(lint_group, strict=False)
-        build_group.add_relationship(gen_group, strict=True)
+        build_group.depends_on(lint_group, mode="order-only")
+        build_group.depends_on(gen_group, mode="strict")
 
         audit_group = self.group("audit", description="Tasks that perform auditing on built artefacts and code")
-        audit_group.add_relationship(build_group, strict=True)
-        audit_group.add_relationship(gen_group, strict=True)
+        audit_group.depends_on(build_group, mode="strict")
+        audit_group.depends_on(gen_group, mode="strict")
 
         test_group = self.group("test", description="Tasks that perform unit tests.", default=True)
-        test_group.add_relationship(build_group, strict=False)
-        test_group.add_relationship(gen_group, strict=True)
+        test_group.depends_on(build_group, mode="order-only")
+        test_group.depends_on(gen_group, mode="strict")
 
         integration_test_group = self.group("integrationTest", description="Tasks that perform integration tests.")
-        integration_test_group.add_relationship(test_group, strict=False)
-        integration_test_group.add_relationship(gen_group, strict=True)
+        integration_test_group.depends_on(test_group, mode="order-only")
+        integration_test_group.depends_on(gen_group, mode="strict")
 
         publish_group = self.group("publish", description="Tasks that publish build artefacts.")
-        publish_group.add_relationship(integration_test_group, strict=False)
-        publish_group.add_relationship(build_group, strict=True)
+        publish_group.depends_on(integration_test_group, mode="order-only")
+        publish_group.depends_on(build_group, mode="strict")
 
         deploy_group = self.group("deploy", description="Tasks that deploy applications.")
-        deploy_group.add_relationship(publish_group, strict=False)
+        deploy_group.depends_on(publish_group, mode="order-only")
 
         self.group("update", description="Tasks that update dependencies of the project.")
 
@@ -112,7 +112,7 @@ class Project(KrakenObject, MetadataContainer, Currentable["Project"]):
         """Returns the recommended build directory for the project; this is a directory inside the context
         build directory ammended by the project name."""
 
-        return self.context.build_directory / self.path.replace(":", "/").lstrip("/")
+        return self.context.build_directory / str(self.address).replace(":", "/").lstrip("/")
 
     def task(self, name: str) -> Task:
         """Return a task in the project by name."""

--- a/kraken-core/src/kraken/core/system/task.py
+++ b/kraken-core/src/kraken/core/system/task.py
@@ -10,7 +10,6 @@ import dataclasses
 import enum
 import logging
 import shlex
-import warnings
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -29,9 +28,12 @@ from typing import (
     overload,
 )
 
+from deprecated import deprecated
 from kraken.common import Supplier
+from typing_extensions import Literal
 
 from kraken.core.address import Address
+from kraken.core.system.kraken_object import KrakenObject
 from kraken.core.system.property import Property, PropertyContainer
 from kraken.core.system.task_supplier import TaskSupplier
 
@@ -59,6 +61,7 @@ class _Relationship(Generic[T]):
 
 
 TaskRelationship = _Relationship["Task"]
+RelationshipMode = Literal["strict", "order-only"]
 
 
 class TaskStatusType(enum.Enum):
@@ -172,67 +175,78 @@ class TaskStatus:
         )
 
 
-class Task(PropertyContainer, abc.ABC):
-    """A task is an isolated unit of work that is configured with properties. Every task has some common settings that
-    are not treated as properties, such as it's :attr:`name`, :attr:`default` and :attr:`capture` flag. A task is a
-    member of a :class:`Project` and can be uniquely identified with a path that is derived from its project and name.
+class Task(KrakenObject, PropertyContainer, abc.ABC):
+    """
+    A Kraken Task is a unit of work that can be executed.
 
-    A task can have a relationship to any number of other tasks. Relationships are directional and the direction can
-    be inverted. A strict relationship indicates that one task *must* run before the other, while a non-strict
-    relationship only dictates the order of tasks if both were to be executed (and prevents the task from being
-    executed in parallel).
+    Tasks goe through a number of stages during its lifetime:
+
+    * Creation and configuration
+    * Finalization (:meth:`finalize`) -- Mutations to properties of the task are locked after this.
+    * Preparation (:meth:`prepare`) -- The task prepares itself for execution; it may indicate that it
+        does not need to be executed at this state.
+    * Execution (:meth:`execute`) -- The task executes its logic.
+
+    Tasks are uniquely identified by their name and the project they belong to, which is also represented
+    by the tasks's :property:`address`. Relationhips to other tasks can be added via the :meth:`depends_on`
+    and `required_by` methods, or by passing properties of one task into the properties of another.
     """
 
-    address: Address
-    project: Project
+    #: A human readable description of the task's purpose. This is displayed in the terminal upon
+    #: closer inspection of a task.
     description: Optional[str] = None
+
+    #: Whether the task executes by default when no explicit task is selected to run on the command-line.
     default: bool = False
+
+    #: Whether the task was explicitly selected on the command-line.
     selected: bool = False
+
+    #: A logger that is bound to the task's address. Use this logger to log messages related to the task,
+    #: for example when implementing :meth:`finalize`, :meth:`prepare` or :meth:`execute`.
     logger: logging.Logger
-    outputs: List[Any]
 
     def __init__(self, name: str, project: Project) -> None:
+        from kraken.core.system.project import Project
+
+        assert isinstance(name, str), type(name)
+        assert isinstance(project, Project), type(project)
+        KrakenObject.__init__(self, name, project)
         PropertyContainer.__init__(self)
-        self._capture = False
-        self.address = project.address.append(name)
-        self.project = project
         self.logger = logging.getLogger(f"{self.path} [{type(self).__module__}.{type(self).__qualname__}]")
-        self.outputs = []
-        self.__relationships: list[_Relationship[str | Task]] = []
+        self._outputs: list[Any] = []
+        self.__relationships: list[_Relationship[Address | Task]] = []
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.path})"
 
     @property
-    def capture(self) -> bool:
-        warnings.warn(
-            "The Task.capture attribute will be deprecated in a future version.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._capture
+    def project(self) -> Project:
+        """
+        A convenient alias for :attr:`parent` which is a lot easier to understand when reading the code.
+        """
 
-    @capture.setter
-    def capture(self, value: bool) -> None:
-        warnings.warn(
-            "The Task.capture attribute will be deprecated in a future version.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self._capture = value
+        assert isinstance(self._parent, Project), "Task.parent must be a Project"
+        return self._parent
+
+    ###
+    # Begin: Deprecated APIs
+    ###
 
     @property
-    def name(self) -> str:
-        return self.address.name
-
-    # TODO(NiklasRosenstein): Deprecated in v0.13.0
-    @property
+    @deprecated(reason="Task.path is deprecated, use str(Task.address) instead.")
     def path(self) -> str:
         return str(self.address)
 
+    @property
+    @deprecated(reason="Task.outputs is deprecated.")
+    def outputs(self) -> list[Any]:
+        return self._outputs
+
+    @deprecated(reason="Task.add_relationship() is deprecated, use Task.depends_on() or Task.required_by() instead.")
     def add_relationship(
         self,
-        task_or_selector: Task | Sequence[Task] | str,
+        task_or_selector: Task | Sequence[Task | Address] | Address | str,
         strict: bool = True,
         inverse: bool = False,
     ) -> None:
@@ -248,6 +262,8 @@ class Task(PropertyContainer, abc.ABC):
         """
 
         if isinstance(task_or_selector, (Task, str)):
+            if isinstance(task_or_selector, str):
+                task_or_selector = Address(task_or_selector)
             self.__relationships.append(_Relationship(task_or_selector, strict, inverse))
         elif isinstance(task_or_selector, Sequence):
             for idx, task in enumerate(task_or_selector):
@@ -257,14 +273,53 @@ class Task(PropertyContainer, abc.ABC):
                         f"{type(task_or_selector).__name__}"
                     )
             for task in task_or_selector:
+                if isinstance(task, str):
+                    task = Address(task)
                 self.__relationships.append(_Relationship(task, strict, inverse))
         else:
             raise TypeError(
                 f"task_or_selector argument must be Task | Sequence[Task] | str, got {type(task_or_selector).__name__}"
             )
 
+    # End: Deprecated APIs
+
+    def depends_on(
+        self, *tasks: Task | Address | str, mode: RelationshipMode = "strict", _inverse: bool = False
+    ) -> None:
+        """
+        Declare that this task depends on the specified other tasks. Relationships are lazy, meaning references
+        to tasks using an address will be evaluated when :meth:`get_relationships` is called.
+
+        If the *mode* is set to `strict`, the relationship is considered a strong dependency, meaning that the
+        dependent task must be executed after the dependency. If the *mode* is set to `order-only`, the relationship
+        indicates only the order in which the tasks must be executed if both were to be executed in the same run.
+        """
+
+        for idx, task in enumerate(tasks):
+            if isinstance(task, str):
+                task = Address(task)
+            if not isinstance(task, Address | Task):
+                raise TypeError(f"tasks[{idx}] must be Address | Task | str, got {type(task).__name__}")
+            self.__relationships.append(_Relationship(task, mode == "strict", _inverse))
+
+    def required_by(self, *tasks: Task | Address | str, mode: RelationshipMode = "strict") -> None:
+        """
+        Declare that this task is required by the specified other tasks. This is the inverse of :meth:`depends_on`,
+        effectively declaring the same relationship in the opposite direction.
+        """
+
+        self.depends_on(*tasks, mode=mode, _inverse=True)
+
     def get_relationships(self) -> Iterable[TaskRelationship]:
-        """Iterates over the relationships to other tasks based on the property provenance."""
+        """
+        Return an iterable that yields all relationships that this task has to other tasks as indicated by
+        information available in the task itself. The method will not return relationships established to
+        this task from other tasks.
+
+        The iterable will contain every relationship that is declared via :meth:`depends_on` or :meth:`required_by`,
+        as well as relationships that are implied by the task's properties. For example, if a property of this
+        task is set to the value of a property of another task, a relationship is implied between the tasks.
+        """
 
         # Derive dependencies through property lineage.
         for key in self.__schema__:
@@ -279,7 +334,7 @@ class Task(PropertyContainer, abc.ABC):
 
         # Manually added relationships.
         for rel in self.__relationships:
-            if isinstance(rel.other_task, str):
+            if isinstance(rel.other_task, Address):
                 try:
                     resolved_tasks = self.project.context.resolve_tasks([rel.other_task], relative_to=self.project)
                 except ValueError as exc:
@@ -291,8 +346,10 @@ class Task(PropertyContainer, abc.ABC):
                 yield cast(TaskRelationship, rel)
 
     def get_description(self) -> str | None:
-        """Return the task's description. The default implementation formats the :attr:`description` string with the
-        task's properties. Any Path property will be converted to a relative string to assist the reader."""
+        """
+        Return the task's description. The default implementation formats the :attr:`description` string with the
+        task's properties. Any Path property will be converted to a relative string to assist the reader.
+        """
 
         class _MappingProxy:
             def __getitem__(_, key: str) -> Any:
@@ -333,6 +390,7 @@ class Task(PropertyContainer, abc.ABC):
 
         :param output_type: The output type to search for."""
 
+    # @deprecated(reason="Rely on the target-rule system to derive the artifacts of a task.")
     def get_outputs(self, output_type: type[T] | type[object] = object) -> Iterable[T] | Iterable[Any]:
         results = []
 
@@ -350,9 +408,11 @@ class Task(PropertyContainer, abc.ABC):
         return results
 
     def finalize(self) -> None:
-        """This method is called by :meth:`Context.finalize()`. It gives the task a chance update its
+        """
+        This method is called by :meth:`Context.finalize()`. It gives the task a chance update its
         configuration before the build process is executed. The default implementation finalizes all non-output
-        properties, preventing them to be further mutated."""
+        properties, preventing them to be further mutated.
+        """
 
         for key in self.__schema__:
             prop: Property[Any] = getattr(self, key)
@@ -360,7 +420,8 @@ class Task(PropertyContainer, abc.ABC):
                 prop.finalize()
 
     def prepare(self) -> TaskStatus | None:
-        """Called before a task is executed. This is called from the main process to check for example if the task
+        """
+        Called before a task is executed. This is called from the main process to check for example if the task
         is skippable or up to date. The implementation of this method should be quick to determine the task status,
         otherwise it should be done in :meth:`execute`.
 
@@ -372,7 +433,8 @@ class Task(PropertyContainer, abc.ABC):
 
     @abc.abstractmethod
     def execute(self) -> TaskStatus | None:
-        """Implements the behaviour of the task. The task can assume that all strict dependencies have been executed
+        """
+        Implements the behaviour of the task. The task can assume that all strict dependencies have been executed
         successfully. Output properties of dependency tasks that are only written by the task's execution are now
         accessible.
 
@@ -383,9 +445,11 @@ class Task(PropertyContainer, abc.ABC):
         raise NotImplementedError
 
     def teardown(self) -> TaskStatus | None:
-        """This method is called only if the task returns :attr:`TaskStatusType.STARTED` from :meth:`execute`. It is
+        """
+        This method is called only if the task returns :attr:`TaskStatusType.STARTED` from :meth:`execute`. It is
         called if _all_ direct dependants of the task have been executed (whether successfully or not) or if no further
-        task execution is queued."""
+        task execution is queued.
+        """
 
         return None
 

--- a/kraken-core/src/kraken/core/system/task.py
+++ b/kraken-core/src/kraken/core/system/task.py
@@ -226,6 +226,7 @@ class Task(KrakenObject, PropertyContainer, abc.ABC):
         A convenient alias for :attr:`parent` which is a lot easier to understand when reading the code.
         """
 
+        from kraken.core.system.project import Project
         assert isinstance(self._parent, Project), "Task.parent must be a Project"
         return self._parent
 

--- a/kraken-core/src/kraken/core/system/task.py
+++ b/kraken-core/src/kraken/core/system/task.py
@@ -218,7 +218,7 @@ class Task(KrakenObject, PropertyContainer, abc.ABC):
         self.__relationships: list[_Relationship[Address | Task]] = []
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self.path})"
+        return f"{type(self).__name__}({self.address})"
 
     @property
     def project(self) -> Project:
@@ -227,6 +227,7 @@ class Task(KrakenObject, PropertyContainer, abc.ABC):
         """
 
         from kraken.core.system.project import Project
+
         assert isinstance(self._parent, Project), "Task.parent must be a Project"
         return self._parent
 

--- a/kraken-core/tests/test_run_in_subproject.py
+++ b/kraken-core/tests/test_run_in_subproject.py
@@ -106,8 +106,8 @@ def test__main__run_in_plain_project_from_subdirectory(tempdir: Path, task_selec
         assert (tempdir / "root.txt").is_file()
     else:
         assert str(excinfo.value) == (
-            "Could not resolve address ':sub:**:task' in context ':'. The failure occurred at address ':sub' "
-            "trying to resolve the remainder '**:task'. The address ':sub:**:task' does not exist."
+            "Could not resolve address ':sub:**:task' in context ':'. The failure occurred at address ':' "
+            "trying to resolve the remainder 'sub:**:task'. The address ':sub' does not exist."
         )
 
 

--- a/kraken-std/src/kraken/std/cargo/__init__.py
+++ b/kraken-std/src/kraken/std/cargo/__init__.py
@@ -92,7 +92,7 @@ def cargo_sqlx_prepare(
     # Preparing or checking sqlx metadata calls `cargo metadata`, which can require the auth proxy
     # Without the auth proxy, cargo sqlx commands would fail with a cryptic error
     # See https://github.com/launchbadge/sqlx/pull/2222 for details
-    task.add_relationship(f":{CARGO_BUILD_SUPPORT_GROUP_NAME}?")
+    task.depends_on(f":{CARGO_BUILD_SUPPORT_GROUP_NAME}?")
 
     return task
 
@@ -143,7 +143,7 @@ def cargo_auth_proxy(*, project: Project | None = None) -> CargoAuthProxyTask:
     # The auth proxy injects values into the cargo config, the cargoSyncConfig.check ensures that it reflects
     # the temporary changes that should be made to the config. The check has to run before the auth proxy,
     # otheerwise it is garuanteed to fail.
-    task.add_relationship(":cargoSyncConfig.check?", strict=False)
+    task.depends_on(":cargoSyncConfig.check?", mode="order-only")
     return task
 
 
@@ -193,7 +193,7 @@ def cargo_clippy(
     )
 
     # Clippy builds your code.
-    task.add_relationship(f":{CARGO_BUILD_SUPPORT_GROUP_NAME}?")
+    task.depends_on(f":{CARGO_BUILD_SUPPORT_GROUP_NAME}?")
 
     return task
 
@@ -242,7 +242,7 @@ def cargo_fmt(*, all_packages: bool = False, project: Project | None = None) -> 
 def cargo_update(*, project: Project | None = None) -> CargoUpdateTask:
     project = project or Project.current()
     task = project.do("cargoUpdate", CargoUpdateTask, group="update")
-    task.add_relationship(":cargoBuildSupport", strict=True)
+    task.depends_on(":cargoBuildSupport")
 
     return task
 
@@ -277,7 +277,7 @@ def cargo_bump_version(
         cargo_toml_file=cargo_toml_file,
     )
 
-    task.add_relationship(":test?")
+    task.depends_on(":test?")
 
     return task
 
@@ -327,7 +327,7 @@ def cargo_build(
         additional_args=additional_args,
         env=Supplier.of_callable(lambda: {**cargo.build_env, **(env or {})}),
     )
-    task.add_relationship(f":{CARGO_BUILD_SUPPORT_GROUP_NAME}?")
+    task.depends_on(f":{CARGO_BUILD_SUPPORT_GROUP_NAME}?")
     return task
 
 
@@ -355,7 +355,7 @@ def cargo_test(
         incremental=incremental,
         env=Supplier.of_callable(lambda: {**cargo.build_env, **(env or {})}),
     )
-    task.add_relationship(f":{CARGO_BUILD_SUPPORT_GROUP_NAME}?")
+    task.depends_on(f":{CARGO_BUILD_SUPPORT_GROUP_NAME}?")
     return task
 
 
@@ -401,7 +401,7 @@ def cargo_publish(
         env=Supplier.of_callable(lambda: {**cargo.build_env, **(env or {})}),
     )
 
-    task.add_relationship(f":{CARGO_PUBLISH_SUPPORT_GROUP_NAME}?")
+    task.depends_on(f":{CARGO_PUBLISH_SUPPORT_GROUP_NAME}?")
 
     return task
 

--- a/kraken-std/src/kraken/std/docker/manifest_tool.py
+++ b/kraken-std/src/kraken/std/docker/manifest_tool.py
@@ -60,5 +60,5 @@ def manifest_tool(
 ) -> ManifestToolPushTask:
     project = Project.current()
     task = project.do(name, ManifestToolPushTask, group=group, template=template, target=target, platforms=platforms)
-    task.add_relationship(inputs)
+    task.depends_on(*inputs)
     return task


### PR DESCRIPTION
- kraken-core/: breaking change: Remove deprecated `Project.children()` method and deprecated `Project.subproject()` overloads.
- kraken-core/: breaking change: Change `Addressable.address` into a read-only property
- fix call to `Project.subproject()` in `Context.get_project()`
- kraken-core/: improvement: Make `Project` a subclass of the new `KrakenObject` class
- kraken-core/: breaking change: Remove `Task.capture`
- fix tests
- kraken-core/: fix: Move `Address.Element` class definition to the global scope, as otherwise we run into an issue with Dill deserialization where the type of `Address.elements` items is not actually the `Address.Element` type that we can access at runtime. (See https://github.com/uqfoundation/dill/issues/600).
- kraken-core/: breaking change: `TaskGraph` implementation now stores `Address` keys instead of strings
