### PR TITLE
kraken-core/: fix: Rework task description wrapping

### DIFF
--- a/kraken-core/.changelog/_unreleased.toml
+++ b/kraken-core/.changelog/_unreleased.toml
@@ -3,6 +3,7 @@ id = "cb501ed7-e633-4a73-bd0e-0e95bdeeb96d"
 type = "fix"
 description = "Rework task description wrapping"
 author = "jon.gjengset@helsing.ai"
+pr = "https://github.com/kraken-build/kraken-build/pull/98"
 issues = [
     "https://github.com/kraken-build/kraken-build/issues/93",
 ]

--- a/kraken-core/.changelog/_unreleased.toml
+++ b/kraken-core/.changelog/_unreleased.toml
@@ -1,0 +1,8 @@
+[[entries]]
+id = "cb501ed7-e633-4a73-bd0e-0e95bdeeb96d"
+type = "fix"
+description = "Rework task description wrapping"
+author = "jon.gjengset@helsing.ai"
+issues = [
+    "https://github.com/kraken-build/kraken-build/issues/93",
+]

--- a/kraken-core/src/kraken/core/cli/main.py
+++ b/kraken-core/src/kraken/core/cli/main.py
@@ -296,7 +296,7 @@ def ls(graph: TaskGraph) -> None:
     if not all_tasks:
         print("no tasks")
         sys.exit(1)
-    longest_name = max(map(len, (str(t.address) for t in all_tasks))) + 1
+    longest_name = max(map(len, (str(t.address) for t in all_tasks)))
 
     print()
     print(colored("Tasks", "blue", attrs=["bold", "underline"]))
@@ -304,32 +304,59 @@ def ls(graph: TaskGraph) -> None:
 
     width = get_terminal_width(120)
 
+    # Because we want to left-indent every line by "  ",
+    # we should treat the terminal as being 2 columns narrower.
+    width -= 2
+
     def _print_task(task: Task) -> None:
-        line = [str(task.address).ljust(longest_name)]
-        remaining_width = width - len(line[0])
+        lines = [str(task.address).ljust(longest_name)]
+        remaining_width = width - len(lines[0])
         if task in goal_tasks:
-            line[0] = colored(line[0], "green")
+            lines[0] = colored(lines[0], "green")
         if task.default:
-            line[0] = colored(line[0], attrs=["bold"])
+            lines[0] = colored(lines[0], attrs=["bold"])
         status = graph.get_status(task)
         if status is not None:
-            line.append(f"[{status_to_text(status)}]")
+            lines[-1] += f" [{status_to_text(status)}]"
             status_length = 2 + len(status_to_text(status, colored=False)) + 1
             remaining_width -= status_length
         description = task.get_description()
         if description:
-            remaining_width -= 2
-            if remaining_width <= 0:
-                remaining_width = width
+            # Only place the description in its own column if there is
+            # sufficient room that it doesn't become awkward to read.
+            #
+            #  - If at least 48 columns are available, wrap the description.
+            #    48 columns is just wide enough that reading wrapped text isn't
+            #    too painful.
+            #  - If the full description fits in the remaining space, do that.
+            #  - If the full description fits on two wrapped lines, do that.
+            #  - Otherwise, put the description on the next line.
+            if remaining_width > 48 or len(description) < 2 * remaining_width:
+                # This is another column, so add a bit of extra spacing
+                lines[-1] += "  "
+                remaining_width -= 2
+                lead = (width - remaining_width) * " "
+            else:
+                # Use a new line. Still wrap the description so we don't end
+                # up with super-long lines of text, which are hard to follow.
+                remaining_width = 80
+                lines.append("")
+                lead = ""
+
+            # Wrap the description in the remaining space,
+            # and indent lines beyond the first so they line up with the first.
             parts = textwrap.wrap(description, remaining_width)
-            line.append(parts[0])  # the first line is already indented
-            line.append("\n")
+            lines[-1] += parts[0]  # the first line is already indented
             for part in parts[1:]:
-                line.append((width - remaining_width - 1) * " ")
-                line.append(part)
-                line.append("\n")
-            line.pop()
-        print("  " + " ".join(line))
+                lines.append(lead)
+                lines[-1] += part
+
+            # If we decided to use the full line for the description, add some
+            # vertical spacing before the next task to avoid visual clutter.
+            if lead == "":
+                lines.append("")
+
+        print("  " + "\n  ".join(lines))
 
     def sort_key(task: Task) -> str:
         return str(task.address)


### PR DESCRIPTION
This is a follow-up to #94. It started because I noticed a boundary-condition bug where descriptions that came all the way up to right side of the terminal seemed to have an extra newline added to them. That turned out to be because every line got an extra space added to it, so all the lines ended up one character too long, and then regular terminal wrapping kicked in.

This caused me to dig further into how exactly the description-rendering code was set up, which led me to find some more oddities. So I decided to make two bigger changes to the code.

First, it no longer joins `line` by spaces, but instead joins by `\n`, with every string-append to a line prefixing its own separator (`+= " "`). This makes it easier to determine where line breaks actually come from, and avoids spurious spaces from appearing.

And second, if there is so little room remaining on a line that it would look weird when wrapped (see code comment for how that's evaluated), the description is now moved to the next line and wrapped independently to 80 characters wide. If this happens, extra vertical spacing is also added before the next task.

I've tested this by adjusting the description and task status of a number of tasks and running `kraken q ls` to verify that the output (subjectively) looks readable and sane. That's also how I landed on 48 characters as the "right" place to flip between column and next-line mode.

Some screenshots:
<img width="1280" alt="Screenshot 2023-08-04 at 11 00 33" src="https://github.com/kraken-build/kraken-build/assets/176295/2d3d775d-91d9-4083-8ad8-e725e6edabaf">
<img width="1281" alt="Screenshot 2023-08-04 at 11 01 55" src="https://github.com/kraken-build/kraken-build/assets/176295/e08f6622-abad-46de-9551-c14a6292ad88">
<img width="1279" alt="Screenshot 2023-08-04 at 11 02 25" src="https://github.com/kraken-build/kraken-build/assets/176295/38fe5529-8100-4b91-8dca-8e309350dce6">
