### PR TITLE
Draft: Add get_lockfile() method to PythonBuildSystems

### DIFF
--- a/kraken-std/src/kraken/std/python/buildsystem/__init__.py
+++ b/kraken-std/src/kraken/std/python/buildsystem/__init__.py
@@ -72,6 +72,10 @@ class PythonBuildSystem(abc.ABC):
     def get_pyproject_reader(self, pyproject: Pyproject) -> PyprojectHandler:
         """Return an object able to read the pyproject file depending on the build system."""
 
+    @abc.abstractmethod
+    def get_lockfile(self) -> Path | None:
+        """Return the lockfile specific to this buildsystem, or None if not supported."""
+
 
 class ManagedEnvironment(abc.ABC):
     """Abstraction of a managed Python environment."""

--- a/kraken-std/src/kraken/std/python/buildsystem/maturin.py
+++ b/kraken-std/src/kraken/std/python/buildsystem/maturin.py
@@ -206,6 +206,9 @@ class MaturinPoetryPythonBuildSystem(PoetryPythonBuildSystem):
 
     def build(self, output_directory: Path, as_version: str | None = None) -> list[Path]:
         return self._builder.build(output_directory, as_version)
+    
+    def get_lockfile(self) -> Path | None:
+        return self.project_directory / "poetry.lock"
 
 
 class MaturinPoetryManagedEnvironment(PoetryManagedEnvironment):
@@ -253,6 +256,8 @@ class MaturinPdmPythonBuildSystem(PDMPythonBuildSystem):
     def build(self, output_directory: Path, as_version: str | None = None) -> list[Path]:
         return self._builder.build(output_directory, as_version)
 
+    def get_lockfile(self) -> Path | None:
+        return self.project_directory / "pdm.lock"
 
 class MaturinPdmManagedEnvironment(PDMManagedEnvironment):
     def always_install(self) -> bool:

--- a/kraken-std/src/kraken/std/python/buildsystem/pdm.py
+++ b/kraken-std/src/kraken/std/python/buildsystem/pdm.py
@@ -193,6 +193,9 @@ class PDMPythonBuildSystem(PythonBuildSystem):
             pyproject.raw.save()
 
         return dst_files
+    
+    def get_lockfile(self) -> Path | None:
+        return self.project_directory / "pdm.lock"
 
 
 class PDMManagedEnvironment(ManagedEnvironment):

--- a/kraken-std/src/kraken/std/python/buildsystem/poetry.py
+++ b/kraken-std/src/kraken/std/python/buildsystem/poetry.py
@@ -216,6 +216,9 @@ class PoetryPythonBuildSystem(PythonBuildSystem):
                 update_python_version_str_in_source_files(previous_version, package_dir)
 
         return dst_files
+    
+    def get_lockfile(self) -> Path | None:
+        return self.project_directory / "poetry.lock"
 
 
 class PoetryManagedEnvironment(ManagedEnvironment):

--- a/kraken-std/src/kraken/std/python/buildsystem/slap.py
+++ b/kraken-std/src/kraken/std/python/buildsystem/slap.py
@@ -74,6 +74,9 @@ class SlapPythonBuildSystem(PythonBuildSystem):
             for src, dst in zip(src_files, dst_files):
                 shutil.move(str(src), dst)
         return dst_files
+    
+    def get_lockfile(self) -> Path | None:
+        return None
 
 
 class SlapManagedEnvironment(ManagedEnvironment):


### PR DESCRIPTION
I need a buildsystem-independent way to retrieve the lockfile path, this change therefore adds the `get_lockfile()` method to all `PythonBuildSystem` subclasses.