### PR TITLE
Add '--strip' command to maturin

### DIFF
--- a/kraken-std/src/kraken/std/python/buildsystem/maturin.py
+++ b/kraken-std/src/kraken/std/python/buildsystem/maturin.py
@@ -104,6 +104,7 @@ class _MaturinBuilder:
                 "maturin",
                 "build",
                 "--release",
+                "--strip",
                 "--zig",
                 "--target",
                 target.target,


### PR DESCRIPTION
Produces far, far smaller binaries - from megabytes to hundreds of kilobytes.