### PR TITLE
Use self-hosted runners for CI jobs

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   test:
-    runs-on: [ self-hosted ]
+    runs-on: [ self-hosted, "arch:amd64" ]
     strategy:
       matrix:
         include:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     strategy:
       matrix:
         include:

--- a/.github/workflows/selftest.yaml
+++ b/.github/workflows/selftest.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   selftest:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted ]
     steps:
     - uses: actions/checkout@v3
     - uses: NiklasRosenstein/slap@gha/install/v1

--- a/.github/workflows/selftest.yaml
+++ b/.github/workflows/selftest.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   selftest:
-    runs-on: [ self-hosted ]
+    runs-on: [ self-hosted, "arch:amd64" ]
     steps:
     - uses: actions/checkout@v3
     - uses: NiklasRosenstein/slap@gha/install/v1


### PR DESCRIPTION
They _should_ get the job done quicker.

__todo__

* Need to install Rustup on the runners
* Maybe make them run inside a Docker container for reproducability?