### PR TITLE
Add workspace flag to cargo_test

### DIFF
--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -25,3 +25,10 @@ pr = "https://github.com/kraken-build/kraken/pull/129"
 issues = [
     "https://github.com/kraken-build/kraken/issues/126",
 ]
+
+[[entries]]
+id = "9116f380-7725-4d2d-872a-ffbc926d80e5"
+type = "improvement"
+description = "Add flag to run all workspace tests"
+author = "@asmello"
+pr = "https://github.com/kraken-build/kraken/pull/135"

--- a/kraken-build/src/kraken/std/cargo/__init__.py
+++ b/kraken-build/src/kraken/std/cargo/__init__.py
@@ -363,6 +363,7 @@ def cargo_test(
     project: Project | None = None,
     features: list[str] | None = None,
     depends_on: Sequence[Task] = (),
+    workspace: bool | None = None,
 ) -> CargoTestTask:
     """Creates a task that runs `cargo test`.
 
@@ -370,7 +371,8 @@ def cargo_test(
         specified, the option is not specified and the default behaviour is used.
     :param env: Override variables for the build environment variables. Values in this dictionary override
         variables in :attr:`CargoProject.build_env`.
-    :param features: List of Cargo features to enable in the build."""
+    :param features: List of Cargo features to enable in the build.
+    :param workspace: Run tests in all workspace crates (by default only the default members are selected)."""
 
     project = project or Project.current()
     cargo = CargoProject.get_or_create(project)
@@ -381,6 +383,8 @@ def cargo_test(
         # `cargo build` expects features to be comma separated, in one string.
         # for example `cargo build --features abc,efg` instead of `cargo build --features abc efg`.
         additional_args.append(",".join(features))
+    if workspace:
+        additional_args.append("--workspace")
 
     task = project.task("cargoTest", CargoTestTask, group=group)
     task.incremental = incremental

--- a/kraken-build/src/kraken/std/git/__init__.py
+++ b/kraken-build/src/kraken/std/git/__init__.py
@@ -43,7 +43,7 @@ def gitignore(
     task = project.task(name, tasks.GitignoreSyncTask, group=group)
     task.file.set(Path(gitignore_file))
     if generated_content is not None:
-        task.generated_content.setmap(lambda x: [*x, *generated_content])  # type: ignore[misc]  # See https://github.com/python/mypy/issues/14891  # noqa: E501
+        task.generated_content.setmap(lambda x: [*x, *generated_content])
     task.gitignore_io_tokens.set(list(gitignore_io_tokens))
     task.gitignore_io_allow_http_request_backfill.set(gitignore_io_allow_http_request_backfill)
     task.where.set(where)


### PR DESCRIPTION
This flag helps ensuring that all tests across all crates are applied, and not just the default ones. It matches the same flag that already exists in `cargo_build`.