### PR TITLE
Fix `kraken run -X <task>` option to correctly not mark a required task as skipped

### DIFF
--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -44,3 +44,9 @@ id = "fe0b1f91-f9fa-4b4c-bdb2-b7f683ab8af7"
 type = "tests"
 description = "Add a unit test for a real-world example of a DAG that failed the expected behavior of `TaskGraph.mark_tasks_as_skipped()`."
 author = "niklas.rosenstein@helsing.ai"
+
+[[entries]]
+id = "4c37612d-1831-4f4f-851d-b96e12b5365e"
+type = "fix"
+description = "Replace `Tasks.mark_tasks_as_skipped()` with a simpler implementation that also fixes an issues with second-degree tasks being marked as skipped even if they should not be."
+author = "niklas.rosenstein@helsing.ai"

--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -44,9 +44,11 @@ id = "fe0b1f91-f9fa-4b4c-bdb2-b7f683ab8af7"
 type = "tests"
 description = "Add a unit test for a real-world example of a DAG that failed the expected behavior of `TaskGraph.mark_tasks_as_skipped()`."
 author = "niklas.rosenstein@helsing.ai"
+pr = "https://github.com/kraken-build/kraken/pull/138"
 
 [[entries]]
 id = "4c37612d-1831-4f4f-851d-b96e12b5365e"
 type = "fix"
 description = "Replace `Tasks.mark_tasks_as_skipped()` with a simpler implementation that also fixes an issues with second-degree tasks being marked as skipped even if they should not be."
 author = "niklas.rosenstein@helsing.ai"
+pr = "https://github.com/kraken-build/kraken/pull/138"

--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -38,3 +38,9 @@ id = "90ab0597-03a2-401f-9fba-a78e174fea34"
 type = "breaking change"
 description = "Remove `kraken.std.http` module, use `kraken.common.http` instead"
 author = "niklas.rosenstein@helsing.ai"
+
+[[entries]]
+id = "fe0b1f91-f9fa-4b4c-bdb2-b7f683ab8af7"
+type = "tests"
+description = "Add a unit test for a real-world example of a DAG that failed the expected behavior of `TaskGraph.mark_tasks_as_skipped()`."
+author = "niklas.rosenstein@helsing.ai"

--- a/kraken-build/src/kraken/core/system/graph_test.py
+++ b/kraken-build/src/kraken/core/system/graph_test.py
@@ -323,12 +323,7 @@ def test__TaskGraph__mark_tasks_as_skipped__does_not_skip_task_required_by_anoth
     b.depends_on(c)
 
     graph = TaskGraph(kraken_project.context)
-    with caplog.at_level(logging.DEBUG):
-        graph.mark_tasks_as_skipped(recursive_tasks=[b], reason="test", origin="test", reset=True)
-    assert (
-        "Did not tag task :c as 'skip' because it is required by at least one other task that is not skipped (:a)"
-        in caplog.text
-    )
+    graph.mark_tasks_as_skipped(recursive_tasks=[b], reason="test", origin="test", reset=True)
 
     assert [t.name for t in a.get_tags("skip")] == []
     assert [t.name for t in b.get_tags("skip")] == ["skip"]

--- a/kraken-build/src/kraken/std/helm/__init__.py
+++ b/kraken-build/src/kraken/std/helm/__init__.py
@@ -6,10 +6,9 @@ import dataclasses
 import urllib.parse
 from pathlib import Path
 
-from kraken.common import Supplier
+from kraken.common import Supplier, http
 from kraken.core import Project, Property, Task, TaskStatus
 
-from kraken.common import http
 from . import helmapi
 
 

--- a/kraken-build/tests/kraken_std/integration/helm/test_helm_oci.py
+++ b/kraken-build/tests/kraken_std/integration/helm/test_helm_oci.py
@@ -6,9 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from kraken.common import not_none
+from kraken.common import http, not_none
 from kraken.core import Project
-from kraken.common import http
 from kraken.std.helm import HelmPackageTask, HelmPushTask, helm_settings
 from tests.kraken_std.util.docker import DockerServiceManager
 

--- a/kraken-build/tests/kraken_std/util/docker.py
+++ b/kraken-build/tests/kraken_std/util/docker.py
@@ -7,8 +7,7 @@ import time
 
 import httpx
 
-from kraken.common import flatten
-from kraken.common import http
+from kraken.common import flatten, http
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- fmt
- kraken-build/: tests: Add a unit test for a real-world example of a DAG that failed the expected behavior of `TaskGraph.mark_tasks_as_skipped()`.
- kraken-build/: fix: Replace `Tasks.mark_tasks_as_skipped()` with a simpler implementation that also fixes an issues with second-degree tasks being marked as skipped even if they should not be.
