### PR TITLE
Enable cargo:token as a global-credential-provider

### DIFF
--- a/examples/cargo-hello-world-lib/.cargo/config.toml
+++ b/examples/cargo-hello-world-lib/.cargo/config.toml
@@ -4,3 +4,8 @@ protocol = "sparse"
 
 [net]
 git-fetch-with-cli = true
+
+[registry]
+global-credential-providers = [
+    "cargo:token",
+]

--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -1,0 +1,6 @@
+[[entries]]
+id = "a0755acd-c588-47a7-bd6d-7ade753d1d1e"
+type = "fix"
+description = "Enable cargo:token as a global-credential-provider; this is required since 1.74, which brings authenticated priviate registries"
+author = "quentin.santos@helsing.ai"
+pr = "https://github.com/kraken-build/kraken/pull/140"

--- a/kraken-build/src/kraken/std/cargo/tasks/cargo_sync_config_task.py
+++ b/kraken-build/src/kraken/std/cargo/tasks/cargo_sync_config_task.py
@@ -36,6 +36,7 @@ class CargoSyncConfigTask(RenderFileTask):
 
     def get_file_contents(self, file: Path) -> str | bytes:
         content = tomli.loads(file.read_text()) if not self.replace.get() and file.exists() else {}
+        content.setdefault("registry", {})["global-credential-providers"] = ["cargo:token"]
         content.setdefault("registries", {})["crates-io"] = {"protocol": self.crates_io_protocol.get()}
         for registry in self.registries.get():
             content.setdefault("registries", {})[registry.alias] = {"index": registry.index}

--- a/kraken-build/src/kraken/wrapper/main.py
+++ b/kraken-build/src/kraken/wrapper/main.py
@@ -170,7 +170,7 @@ def auth(prog: str, argv: list[str], use_keyring_if_available: bool) -> NoReturn
         elif args.password:
             password = args.password
         else:
-            password = getpass.getpass(f"Password for {args.host}:")
+            password = getpass.getpass(f"Password for {args.host}: ")
         auth.set_credentials(args.host, args.username, password)
         config.save()
     else:


### PR DESCRIPTION
Enable cargo:token as a global-credential-provider

Since 1.74, Cargo requires a credential provider to be set up to download crates from private registries. This changes set the cargo:token credential provider. This stays compatible with the mitmproxy credentials injection.

This will also be useful when switching to cargo-based authentication instead of relying on credentials injection.