### PR TITLE
Allows specifying which features to build, test and lint

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,7 @@
+[[entries]]
+id = "05ed5af2-2314-4291-9e00-8f5e9d3fe66a"
+type = "feature"
+description = "Adds the features key for CargoBuildTask"
+author = "patrick.elsen@helsing.ai"
+pr = "https://github.com/kraken-build/kraken/issues/151"
+component = "std"

--- a/kraken-build/src/kraken/std/cargo/tasks/cargo_clippy_task.py
+++ b/kraken-build/src/kraken/std/cargo/tasks/cargo_clippy_task.py
@@ -8,13 +8,14 @@ from .cargo_build_task import CargoBuildTask
 class CargoClippyTask(CargoBuildTask):
     """Runs `cargo clippy` for linting or applying suggestions."""
 
+    #: When set to True, tells clippy to fix the issues.
     fix: Property[bool] = Property.default(False)
+
+    #: When running Clippy in Fix mode, allow a dirty or staged Git work tree.
     allow: Property[str | None] = Property.default("staged")
 
-    # CargoBuildTask
-
     def get_cargo_command(self, env: dict[str, str]) -> list[str]:
-        command = ["cargo", "clippy"]
+        command = super().get_cargo_subcommand(env, "clippy")
         if self.fix.get():
             command += ["--fix"]
             allow = self.allow.get()
@@ -24,4 +25,5 @@ class CargoClippyTask(CargoBuildTask):
                 command += ["--allow-dirty", "--allow-staged"]
             elif allow is not None:
                 raise ValueError(f"invalid allow: {allow!r}")
+
         return command

--- a/kraken-build/src/kraken/std/cargo/tasks/cargo_test_task.py
+++ b/kraken-build/src/kraken/std/cargo/tasks/cargo_test_task.py
@@ -1,4 +1,21 @@
+from enum import Enum, auto
+
+from kraken.core import Property
+
 from .cargo_build_task import CargoBuildTask
+
+
+class CargoTestIgnored(Enum):
+    """How to treat ignored tests"""
+
+    #: Skip ignored tests
+    SKIP = auto()
+
+    #: Run ignored tests
+    INCLUDE = auto()
+
+    #: Run only ignored tests
+    ONLY = auto()
 
 
 class CargoTestTask(CargoBuildTask):
@@ -7,6 +24,25 @@ class CargoTestTask(CargoBuildTask):
 
     description = "Run `cargo test`."
 
+    #: When set to a list of filters, run only tests which match any of these filters.
+    filter: Property[list[str]] = Property.default_factory(list)
+
+    #: Specify how to treat ignored tests, by default they are skipped.
+    ignored: Property[CargoTestIgnored] = Property.default(CargoTestIgnored.SKIP)
+
     def get_cargo_command(self, env: dict[str, str]) -> list[str]:
-        super().get_cargo_command(env)
-        return ["cargo", "test"] + self.additional_args.get()
+        command = super().get_cargo_subcommand(env, "test")
+        command.append("--")
+
+        match self.ignored.get():
+            case CargoTestIgnored.SKIP:
+                pass
+            case CargoTestIgnored.INCLUDE:
+                command.append("--include-ignored")
+            case CargoTestIgnored.ONLY:
+                command.append("--ignored")
+
+        for filter in self.filter.get():
+            command.append(filter)
+
+        return command


### PR DESCRIPTION
Rust has the ability to specify optional features (think `#ifdef` in C/C++), as well as default features. When running any of the tooling without additional options (`cargo test`, `cargo build`, `cargo clippy`), only the default features are activated, which means that the code that is behind the other features goes untested, unlinted and unbuilt.

In an ideal world, we would thus run unit tests for every possible subset of the set of possible features. This is possible with `cargo hack`, although it leads to long CI times and is thus undesireable. 

A good tradeoff is this:

- Test and lint with `--all-features`
- Use `cargo hack` to just check all possible features to make sure they at least are compileable

This workflow catches the vast majority of issues related to working with feature-gated code. However, this workflow is currently not easily possible because we do not enable `--all-features` on our `cargo_test` and `cargo_clippy` tasks.

What this PR does is add some handles that allow us to enable `--all-features` (or specific features) on our test and clippy
tasks.

Specifically, this gives us some fine control over which features are enabled:

```
# default features
cargo_clippy(features = CargoBuildFeatures())

# no default features, but activate a and b
cargo_clippy(features = CargoBuildFeatures(features = ["a", "b"], default = False))

# enable all features
cargo_clippy(features = CargoBuildFeatures(all = True))
```

The idea is that at some point (after perhaps discussing it), we could change `autoconf()` to setting the features to `CargoBuildFeatures(all = True)` for the test and clippy tasks by default, to make sure that we really do run *all* tests in CI, and not just the ones for the features that happen to be enabled by default.

