### PR TITLE
kraken-build/: improvement: `Currentable.as_current()` now returns self

### DIFF
--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "03c2043b-e016-400c-900a-6f0844877de0"
+type = "improvement"
+description = "`Currentable.as_current()` now returns self"
+author = "@NiklasRosenstein"

--- a/kraken-build/src/kraken/core/base/currentable.py
+++ b/kraken-build/src/kraken/core/base/currentable.py
@@ -54,7 +54,7 @@ class Currentable(CurrentProvider[T]):
     __current: ClassVar[Any | None] = None  # note: ClassVar cannot contain type variables
 
     @contextmanager
-    def as_current(self) -> Iterator[None]:
+    def as_current(self) -> Iterator[T]:
         """
         A context manager that makes the instance *self* available globally to be retrieved with :meth:`current`.
 
@@ -64,7 +64,7 @@ class Currentable(CurrentProvider[T]):
         prev = type(self).__current
         try:
             type(self).__current = self
-            yield
+            yield cast(T, self)
         finally:
             type(self).__current = prev
 


### PR DESCRIPTION
This simplifies some code e.g. for testing:

```py
context = Context(Path.cwd())
with context.as_current():
  ...
```

becomes

```py
with Context(Path.cwd()).as_current() as context:
  ...
```