### PR TITLE
kraken-build/: feature: Add `pytest(include_dirs)` to add additional directories for testing

### DIFF
--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "03c2043b-e016-400c-900a-6f0844877de0"
 type = "improvement"
 description = "`Currentable.as_current()` now returns self"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "c778f849-7552-4bde-ace4-34190fa84c8d"
+type = "feature"
+description = "Add `pytest(include_dirs)` to add additional directories for testing"
+author = "@NiklasRosenstein"

--- a/kraken-build/src/kraken/std/python/tasks/pytest_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pytest_task.py
@@ -31,6 +31,7 @@ class PytestTask(EnvironmentAwareDispatchTask):
     python_dependencies = ["pytest"]
 
     tests_dir: Property[Path]
+    include_dirs: Property[Sequence[Path]] = Property.default(())
     ignore_dirs: Property[Sequence[Path]] = Property.default_factory(list)
     allow_no_tests: Property[bool] = Property.default(False)
     doctest_modules: Property[bool] = Property.default(True)
@@ -53,6 +54,7 @@ class PytestTask(EnvironmentAwareDispatchTask):
             "-vv",
             str(self.project.directory / self.settings.source_directory),
             str(self.project.directory / tests_dir),
+            *[str(self.project.directory / path) for path in self.include_dirs.get()],
         ]
         command += flatten(["--ignore", str(self.project.directory / path)] for path in self.ignore_dirs.get())
         command += ["--log-cli-level", "INFO"]
@@ -85,6 +87,7 @@ def pytest(
     group: str = "test",
     project: Project | None = None,
     tests_dir: Path | None = None,
+    include_dirs: Sequence[Path] = (),
     ignore_dirs: Sequence[Path] = (),
     allow_no_tests: bool = False,
     doctest_modules: bool = True,
@@ -94,6 +97,7 @@ def pytest(
     project = project or Project.current()
     task = project.task(name, PytestTask, group=group)
     task.tests_dir = tests_dir
+    task.include_dirs = include_dirs
     task.ignore_dirs = ignore_dirs
     task.allow_no_tests = allow_no_tests
     task.doctest_modules = doctest_modules


### PR DESCRIPTION
This is a bit of a hack to get Pytest to consider `src/kraken/build` in an upcoming PR. A better alternative might be to explicitly configure Pytest's `norecursedirs` (see https://pytest.org/en/7.4.x/example/pythoncollection.html#changing-directory-recursion), but it feels like not recursing into a directory named `build` even if under the `tests/` or `src/` directory is a good default in most cases. 