### PR TITLE
Accept `str` for some `pytest()` parameters, use `venv --upgrade-deps` in kraken-wrapper and store a success flag after build venv creation

### DIFF
--- a/.changelog/0.33.0.toml
+++ b/.changelog/0.33.0.toml
@@ -5,21 +5,25 @@ id = "4b472d25-2152-41f5-a048-fe28f8078b51"
 type = "feature"
 description = "Add `version_spec` argument to `black()`, `flake8()`, `isort()`, `mypy()`, `pycln()`, `pylint()` and `pyupgrade()` factory functions"
 author = "niklas.rosenstein@helsing.ai"
+component = "kraken-build"
 
 [[entries]]
 id = "64923afc-d71a-4a6a-bd5b-c31418acdef4"
 type = "improvement"
 description = "Drastically improve the performance of `kraken.common.findpython.get_candidates()` on Windows and WSL where you would until now test the entire C:/Windows/System32 folder for executable access."
 author = "@NiklasRosenstein"
+component = "kraken-wrapper"
 
 [[entries]]
 id = "f0b6da17-e82e-451b-b919-81529b97cd30"
 type = "feature"
 description = "Add `kraken.build` module which allows importing the current `context` and `project` from a build script as if calling `Context.current()` or `Project.current()`"
 author = "@NiklasRosenstein"
+component = "kraken-build"
 
 [[entries]]
 id = "3bcf3259-8bb2-4c3c-83d8-e5fccd187719"
 type = "feature"
 description = "Add a `PexBuildTask` and add support for most Python tooling tasks to defer to an alternative binary (which the DAG builder can use to point to a PEX)"
 author = "niklas.rosenstein@helsing.ai"
+component = "kraken-build"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,12 +3,14 @@ id = "e70d7845-13ee-42da-9465-2d5509ba7c98"
 type = "improvement"
 description = "Use `--upgrade-deps` option to `python -m venv` instead of calling `pip install --upgrade pip` separately after Venv creation"
 author = "niklas.rosenstein@helsing.ai"
+component = "kraken-wrapper"
 
 [[entries]]
 id = "9fc53062-4c1c-4f87-a744-9b1f66163c12"
 type = "improvement"
 description = "Accept `str` for `pytest(tests_dir, ignore_dirs, include_dirs)` arguments"
 author = "niklas.rosenstein@helsing.ai"
+component = "kraken-build"
 
 [[entries]]
 id = "c3445636-093d-427e-8e5e-7c7571cf1dd7"
@@ -18,3 +20,4 @@ author = "niklas.rosenstein@helsing.ai"
 issues = [
     "https://github.com/kraken-build/kraken/issues/24",
 ]
+component = "kraken-wrapper"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -9,3 +9,12 @@ id = "9fc53062-4c1c-4f87-a744-9b1f66163c12"
 type = "improvement"
 description = "Accept `str` for `pytest(tests_dir, ignore_dirs, include_dirs)` arguments"
 author = "niklas.rosenstein@helsing.ai"
+
+[[entries]]
+id = "c3445636-093d-427e-8e5e-7c7571cf1dd7"
+type = "improvement"
+description = "Store a `.success.flag` file in the virtual build environment to know if the Virtual environment installation was successful."
+author = "niklas.rosenstein@helsing.ai"
+issues = [
+    "https://github.com/kraken-build/kraken/issues/24",
+]

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "e70d7845-13ee-42da-9465-2d5509ba7c98"
+type = "improvement"
+description = "Use `--upgrade-deps` option to `python -m venv` instead of calling `pip install --upgrade pip` separately after Venv creation"
+author = "niklas.rosenstein@helsing.ai"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "e70d7845-13ee-42da-9465-2d5509ba7c98"
 type = "improvement"
 description = "Use `--upgrade-deps` option to `python -m venv` instead of calling `pip install --upgrade pip` separately after Venv creation"
 author = "niklas.rosenstein@helsing.ai"
+
+[[entries]]
+id = "9fc53062-4c1c-4f87-a744-9b1f66163c12"
+type = "improvement"
+description = "Accept `str` for `pytest(tests_dir, ignore_dirs, include_dirs)` arguments"
+author = "niklas.rosenstein@helsing.ai"

--- a/kraken-build/src/kraken/std/python/tasks/pytest_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pytest_task.py
@@ -86,9 +86,9 @@ def pytest(
     name: str = "pytest",
     group: str = "test",
     project: Project | None = None,
-    tests_dir: Path | None = None,
-    include_dirs: Sequence[Path] = (),
-    ignore_dirs: Sequence[Path] = (),
+    tests_dir: Path | str | None = None,
+    include_dirs: Sequence[Path | str] = (),
+    ignore_dirs: Sequence[Path | str] = (),
     allow_no_tests: bool = False,
     doctest_modules: bool = True,
     marker: str | None = None,
@@ -96,9 +96,9 @@ def pytest(
 ) -> PytestTask:
     project = project or Project.current()
     task = project.task(name, PytestTask, group=group)
-    task.tests_dir = tests_dir
-    task.include_dirs = include_dirs
-    task.ignore_dirs = ignore_dirs
+    task.tests_dir = Path(tests_dir) if tests_dir is not None else None
+    task.include_dirs = list(map(Path, include_dirs))
+    task.ignore_dirs = list(map(Path, ignore_dirs))
     task.allow_no_tests = allow_no_tests
     task.doctest_modules = doctest_modules
     task.marker = marker

--- a/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
@@ -148,14 +148,9 @@ class VenvBuildEnv(BuildEnv):
                 )
                 python_origin_bin = sys.executable
 
-            command = [python_origin_bin, "-m", "venv", str(self._path)]
+            command = [python_origin_bin, "-m", "venv", str(self._path), "--upgrade-deps"]
             logger.info("Creating virtual environment at %s", os.path.relpath(self._path))
             self._run_command(command, operation_name="Create virtual environment", log_file=create_log)
-
-            # Upgrade Pip.
-            command = [python_bin, "-m", "pip", "install", "--upgrade", "pip"]
-            logger.info("Upgrading Pip in virtual environment.")
-            self._run_command(command, operation_name="Upgrade Pip", log_file=create_log, mode="a")
 
         else:
             logger.info("Reusing virtual environment at %s", self._path)

--- a/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
@@ -138,8 +138,8 @@ class VenvBuildEnv(BuildEnv):
                     safe_rmpath(self._path)
 
         elif not success_flag.is_file():
-            logger.warning("Your virtual build environment appears to be corrupt. It will be recreated")
-            logger.warning("This usually happens by pressing Ctrl+C during its installation.")
+            logger.warning("Your virtual build environment appears to be corrupt. It will be recreated. This happens")
+            logger.warning("by pressing Ctrl+C during its installation, or if you've recently upgraded kraken-wrapper.")
             safe_rmpath(self._path)
 
         if not self._path.exists():


### PR DESCRIPTION
- improvement: Use `--upgrade-deps` option to `python -m venv` instead of calling `pip install --upgrade pip` separately after Venv creation
- improvement: Accept `str` for `pytest(tests_dir, ignore_dirs, include_dirs)` arguments
- improvement: Store a `.success.flag` file in the virtual build environment to know if the Virtual environment installation was successful.
