### PR TITLE
Add task for building docs with Novella, improve `PexBuildTask` and add `GetItemSupplier`

### DIFF
--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "2f2d584f-2a2a-49cc-b265-56e7b1ed3ce9"
 type = "feature"
 description = "Add `GetItemSupplier` and `Supplier.__getitem__()`"
 author = "niklas.rosenstein@helsing.ai"
+
+[[entries]]
+id = "ee333218-60d5-438d-bcec-bee90bf3c2d2"
+type = "improvement"
+description = "Add `PexBuildTask.output_scripts_dir` and `.output_scripts` properties"
+author = "niklas.rosenstein@helsing.ai"

--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "2f2d584f-2a2a-49cc-b265-56e7b1ed3ce9"
+type = "feature"
+description = "Add `GetItemSupplier` and `Supplier.__getitem__()`"
+author = "niklas.rosenstein@helsing.ai"

--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -9,3 +9,9 @@ id = "ee333218-60d5-438d-bcec-bee90bf3c2d2"
 type = "improvement"
 description = "Add `PexBuildTask.output_scripts_dir` and `.output_scripts` properties"
 author = "niklas.rosenstein@helsing.ai"
+
+[[entries]]
+id = "c47a5861-45f1-4d42-b28a-ef725bf363f6"
+type = "feature"
+description = "add `NovellaTask()` and `novella()` factory function to build documentation with [Novella](https://github.com/NiklasRosenstein/novella/)"
+author = "niklas.rosenstein@helsing.ai"

--- a/kraken-build/src/kraken/common/supplier.py
+++ b/kraken-build/src/kraken/common/supplier.py
@@ -149,7 +149,6 @@ class MapSupplier(Supplier[U], Generic[T, U]):
 
 
 class GetItemSupplier(Supplier[V]):
-
     def __init__(self, key: K, value: Supplier[Mapping[K, V]]) -> None:
         self._key = key
         self._value = value

--- a/kraken-build/src/kraken/common/supplier.py
+++ b/kraken-build/src/kraken/common/supplier.py
@@ -3,13 +3,15 @@ calculated lazily and track provenance of such computations. """
 
 
 import abc
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, Generic, TypeVar
 
 from ._generic import NotSet
 
 T = TypeVar("T", covariant=True)
 U = TypeVar("U")
+K = TypeVar("K")
+V = TypeVar("V")
 
 
 class Supplier(Generic[T], abc.ABC):
@@ -76,6 +78,9 @@ class Supplier(Generic[T], abc.ABC):
 
         return OnceSupplier(self)
 
+    def __getitem__(self: "Supplier[Mapping[K, V]]", key: K) -> "GetItemSupplier[V]":
+        return GetItemSupplier(key, self)
+
     def lineage(self) -> Iterable[tuple["Supplier[Any]", list["Supplier[Any]"]]]:
         """Iterates over all suppliers in the lineage.
 
@@ -141,6 +146,29 @@ class MapSupplier(Supplier[U], Generic[T, U]):
             return False
         assert isinstance(other, MapSupplier)
         return (self._func, self._value) == (other._func, other._value)
+
+
+class GetItemSupplier(Supplier[V]):
+
+    def __init__(self, key: K, value: Supplier[Mapping[K, V]]) -> None:
+        self._key = key
+        self._value = value
+
+    def derived_from(self) -> Iterable[Supplier[Any]]:
+        yield self._value
+
+    def get(self) -> V:
+        value = self._value.get()
+        return value[self._key]
+
+    def __repr__(self) -> str:
+        return f"{self._value}[{self._key}]"
+
+    def __eq__(self, other: object) -> bool:
+        if type(other) is not type(self):
+            return False
+        assert isinstance(other, GetItemSupplier)
+        return (self._key, self._value) == (other._key, other._value)
 
 
 class OnceSupplier(Supplier[T]):

--- a/kraken-build/src/kraken/std/docs/tasks/novella.py
+++ b/kraken-build/src/kraken/std/docs/tasks/novella.py
@@ -1,0 +1,71 @@
+""" Build documentation using [Novella](https://github.com/NiklasRosenstein/novella/). """
+
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+from kraken.core import Project, Property, Task, TaskStatus
+from kraken.std.python.tasks.pex_build_task import pex_build
+
+
+class NovellaTask(Task):
+    """Build or serve documentation with Novella."""
+
+    novella_bin: Property[Path]
+    docs_dir: Property[Path | None] = Property.default(None)
+    args: Property[Sequence[str]] = Property.default(())
+
+    def execute(self) -> TaskStatus | None:
+        command = [str(self.novella_bin.get())]
+        if self.docs_dir.get():
+            command += ["--directory", str(self.docs_dir.get())]
+        command += self.args.get()
+        return TaskStatus.from_exit_code(command, subprocess.call(command, cwd=self.project.directory))
+
+
+def novella(
+    *,
+    project: Project | None = None,
+    name: str = "novella",
+    novella_version: str,
+    additional_requirements: Sequence[str] = (),
+    docs_dir: str | Path | None = None,
+    build_args: Sequence[str] = (),
+    build_task: str | None = None,
+    build_group: str | None = None,
+    serve_args: Sequence[str] | None = None,
+    serve_task: str | None = None,
+) -> tuple[NovellaTask, NovellaTask | None]:
+    project = project or Project.current()
+    novella_bin = pex_build(
+        "novella",
+        requirements=[f"novella{novella_version}", *additional_requirements],
+        project=project,
+    ).output_scripts["novella"]
+
+    if docs_dir is not None:
+        docs_dir = project.directory / docs_dir
+
+    if build_task is None:
+        assert name is not None, "need one of build_task/name"
+        build_task = name
+
+    _build_task = project.task(build_task, NovellaTask)
+    _build_task.novella_bin = novella_bin
+    _build_task.docs_dir = docs_dir
+    _build_task.args = build_args
+    if build_group is not None:
+        project.group(build_group).add(_build_task)
+
+    if serve_args is not None:
+        if serve_task is None:
+            assert name is not None, "need one of serve_task/name"
+            serve_task = f"{name}.serve"
+        _serve_task = project.task(serve_task, NovellaTask)
+        _serve_task.novella_bin = novella_bin
+        _serve_task.docs_dir = docs_dir
+        _serve_task.args = serve_args
+    else:
+        _serve_task = None
+
+    return _build_task, _serve_task

--- a/kraken-build/src/kraken/std/python/tasks/pex_build_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pex_build_task.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-from pex.pex import PEX
+from pex.pex import PEX  # type: ignore[import]
 
 from kraken.core.system.project import Project
 from kraken.core.system.property import Property

--- a/kraken-build/src/kraken/std/python/tasks/pex_build_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pex_build_task.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-from pex.pex import PEX  # type: ignore[import]
+from pex.pex import PEX  # type: ignore[import-untyped]
 
 from kraken.core.system.project import Project
 from kraken.core.system.property import Property

--- a/kraken-build/src/kraken/std/python/tasks/pex_build_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pex_build_task.py
@@ -3,8 +3,10 @@ import logging
 import shlex
 import subprocess
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+
+from pex.pex import PEX
 
 from kraken.core.system.project import Project
 from kraken.core.system.property import Property
@@ -13,9 +15,7 @@ from kraken.core.system.task import Task, TaskStatus
 
 class PexBuildTask(Task):
     """Build a PEX (Python EXecutable) from a Python requirement spec. Useful to install CLIs from PyPI. The PEX
-    will be cached and re-used if the requirements have not changed.
-
-    Important: One of :attr:`console_script` and :attr:`entry_point` is required."""
+    will be cached and re-used if the requirements have not changed."""
 
     binary_name: Property[str]
     requirements: Property[Sequence[str]]
@@ -25,7 +25,18 @@ class PexBuildTask(Task):
     pex_binary: Property[Path | None] = Property.default(None)
     python: Property[Path | None] = Property.default(None)
 
+    #: The path to the built PEX file will be written to this property.
     output_file: Property[Path] = Property.output()
+
+    #: A mapping of all console_script entry points to paths of shell scripts that invoke the PEX using the
+    #: respective script. These scripts set up the PATH in a way that they can automatically call scripts
+    #: from other requirements in the same PEX. You should prefer the console script from this property
+    #: instead of setting the :attr:`console_script` attribute and running the :attr:`output_file` directly
+    #: if your application requires access to the console scripts provided by its other dependencies in the PEX.
+    output_scripts: Property[Mapping[str, Path]] = Property.output()
+
+    #: The directory that contains all `output_scripts`.
+    output_scripts_dir: Property[Path] = Property.output()
 
     def _get_output_file_path(self) -> Path:
         hashsum = hashlib.md5(
@@ -41,17 +52,25 @@ class PexBuildTask(Task):
                 ]
             ).encode()
         ).hexdigest()
-        return (self.project.context.build_directory / ".store" / hashsum / self.binary_name.get()).with_suffix(".pex")
+        return (
+            self.project.context.build_directory
+            / ".store"
+            / f"{hashsum}-{self.binary_name.get()}"
+            / self.binary_name.get()
+        ).with_suffix(".pex")
 
     def prepare(self) -> TaskStatus | None:
-        if not self.entry_point.get() and not self.console_script.get():
-            return TaskStatus.failed("One of the `entry_point` or `console_script` properties must be set")
         self.output_file = self._get_output_file_path().absolute()
         if self.output_file.get().exists():
             return TaskStatus.skipped(f"PEX `{self.binary_name.get()}` already exists ({self.output_file.get()})")
         return TaskStatus.pending()
 
     def execute(self) -> TaskStatus | None:
+        # After building the PEX, we expose all of it's `console_script` entry points as shell scripts
+        # in a separate directory to support when the PEX expects to call a subprocess of one of the
+        # console scripts of its own Python dependencies.
+        console_scripts_dir = self.output_file.get().parent / "bin"
+
         try:
             self.output_file.get().parent.mkdir(parents=True, exist_ok=True)
             _build_pex(
@@ -65,6 +84,32 @@ class PexBuildTask(Task):
             )
         except subprocess.CalledProcessError as exc:
             return TaskStatus.from_exit_code(exc.cmd, exc.returncode)
+
+        # Generate shell scripts that serve as proxies for all the console_script entrypoints in the PEX.
+        # We need to update the PATH in the shell script because there's no way I can see to append to the
+        # PATH in the built PEX file. Technically there's the --venv mode, but it requires the PEX caller
+        # to set `PEX_VENV=true PEX_VENV_BIN_PATH=prepend`.
+
+        console_scripts_files = {}
+        console_scripts = _get_console_scripts(PEX(str(self.output_file.get())))
+        if console_scripts:
+            console_scripts_dir.mkdir(parents=True, exist_ok=True)
+            self.logger.info("Exporting %d console_scripts in PEX to %s", len(console_scripts), console_scripts_dir)
+            for script in console_scripts:
+                file = console_scripts_dir / script
+                console_scripts_files[script] = file
+                file.write_text(
+                    f'#!/bin/sh\nPEX_SCRIPT={script} PATH="{console_scripts_dir.absolute()}:$PATH" '
+                    f'"{self.output_file.get().absolute()}" "$@"\n'
+                    "exit $?\n"
+                )
+                file.chmod(0o777)
+        else:
+            self.logger.info("note: PEX has no console_scripts")
+
+        self.output_scripts_dir = console_scripts_dir
+        self.output_scripts = console_scripts_files
+
         return TaskStatus.succeeded(f"PEX `{self.binary_name.get()}` built successfully ({self.output_file.get()})")
 
 
@@ -75,6 +120,8 @@ def _build_pex(
     entry_point: str | None = None,
     console_script: str | None = None,
     interpreter_constraint: str | None = None,
+    inject_env: Mapping[str, str] | None = None,
+    venv: bool = False,
     pex_binary: Path | None = None,
     python: Path | None = None,
     log: logging.Logger | None = None,
@@ -98,6 +145,7 @@ def _build_pex(
             str(python or sys.executable),
             "-m",
             "pex",
+            "-v",
         ]
 
     command += [
@@ -111,19 +159,36 @@ def _build_pex(
         command += ["--console-script", console_script]
     if interpreter_constraint is not None:
         command += ["--interpreter-constraint", interpreter_constraint]
+    for key, value in (inject_env or {}).items():
+        command += ["--inject-env", f"{key}={value}"]
+    if venv:
+        command += ["--venv"]
 
     (log or logging).info("Building PEX $ %s", " ".join(map(shlex.quote, command)))
     subprocess.run(command, check=True)
 
 
+def _get_console_scripts(pex: PEX) -> set[str]:
+    """Return all entry points registered under `console_script` for this PEX."""
+
+    result = set()
+    for dist in pex.resolve():
+        result.update(dist.get_entry_map().get("console_scripts", {}).keys())
+    return result
+
+
 def pex_build(
-    binary_name: str,
+    binary_name: str | None = None,
+    *,
     requirements: Sequence[str],
     entry_point: str | None = None,
     console_script: str | None = None,
     task_name: str | None = None,
     project: Project | None = None,
 ) -> PexBuildTask:
+    assert binary_name or console_script, "binary_name or console_script must be set"
+    binary_name = binary_name or console_script
+
     task = (project or Project.current()).task(task_name or f"pexBuild.{binary_name}", PexBuildTask)
     task.binary_name = binary_name
     task.requirements = requirements


### PR DESCRIPTION
- kraken-build/: feature: Add `GetItemSupplier` and `Supplier.__getitem__()`
- kraken-build/: improvement: Add `PexBuildTask.output_scripts_dir` and `.output_scripts` properties
- kraken-build/: feature: add `NovellaTask()` and `novella()` factory function to build documentation with [Novella](https://github.com/NiklasRosenstein/novella/)
- fmt
