### PR TITLE
Use latest Pip version and resolver in Pex, and `--venv prepend` to remove our convoluted workaround

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -41,6 +41,6 @@ component = "kraken-build"
 [[entries]]
 id = "93392dac-89fb-452a-acff-fa41e6d914a6"
 type = "improvement"
-description = "Use latest Pip version and resolver in Pex, and `--venv prepend` to remove our convoluted workaround"
+description = "Use latest Pip version and resolver in Pex, and use `--venv prepend` for Novella"
 author = "niklas.rosenstein@helsing.ai"
 component = "kraken-build"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -37,3 +37,10 @@ issues = [
     "https://github.com/kraken-build/kraken/issues/165",
 ]
 component = "kraken-build"
+
+[[entries]]
+id = "93392dac-89fb-452a-acff-fa41e6d914a6"
+type = "improvement"
+description = "Use latest Pip version and resolver in Pex, and `--venv prepend` to remove our convoluted workaround"
+author = "niklas.rosenstein@helsing.ai"
+component = "kraken-build"

--- a/kraken-build/src/kraken/std/docs/tasks/novella.py
+++ b/kraken-build/src/kraken/std/docs/tasks/novella.py
@@ -38,10 +38,8 @@ def novella(
 ) -> tuple[NovellaTask, NovellaTask | None]:
     project = project or Project.current()
     novella_bin = pex_build(
-        "novella",
-        requirements=[f"novella{novella_version}", *additional_requirements],
-        project=project,
-    ).output_scripts["novella"]
+        console_script="novella", requirements=[f"novella{novella_version}", *additional_requirements], project=project
+    ).output_file
 
     if docs_dir is not None:
         docs_dir = project.directory / docs_dir

--- a/kraken-build/src/kraken/std/docs/tasks/novella.py
+++ b/kraken-build/src/kraken/std/docs/tasks/novella.py
@@ -38,7 +38,10 @@ def novella(
 ) -> tuple[NovellaTask, NovellaTask | None]:
     project = project or Project.current()
     novella_bin = pex_build(
-        console_script="novella", requirements=[f"novella{novella_version}", *additional_requirements], project=project
+        console_script="novella",
+        requirements=[f"novella{novella_version}", *additional_requirements],
+        project=project,
+        venv="prepend",
     ).output_file
 
     if docs_dir is not None:


### PR DESCRIPTION
* PEX is not officially supported as a library, and we can use the `--venv prepend` option to make sure that the program can access other `console_scripts` via system calls from the same PEX (see https://github.com/pantsbuild/pex/issues/2323)
* Use the latest Pip version and a modern resolution algorithm to improve requirement resolution and avoid running into conflicts that the legacy resolution algorithm cannot resolve (see https://github.com/pantsbuild/pex/issues/2320)