### PR TITLE
feat: add flags to clippy to cover more cases

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,5 +1,6 @@
 [[entries]]
 id = "c735fee0-cd87-47a6-8c6f-b52463f0f73e"
 type = "feature"
-description = "Add flags to CargoClippyTask to cover more cases"
+description = "Add `workspace`, `all_features` and `deny_warnings` properties to `CargoClippyTask`."
 author = "@tomkarw"
+pr = "https://github.com/kraken-build/kraken/pull/182"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "c735fee0-cd87-47a6-8c6f-b52463f0f73e"
+type = "feature"
+description = "Add flags to CargoClippyTask to cover more cases"
+author = "@tomkarw"

--- a/kraken-build/src/kraken/std/cargo/tasks/cargo_clippy_task.py
+++ b/kraken-build/src/kraken/std/cargo/tasks/cargo_clippy_task.py
@@ -8,13 +8,20 @@ from .cargo_build_task import CargoBuildTask
 class CargoClippyTask(CargoBuildTask):
     """Runs `cargo clippy` for linting or applying suggestions."""
 
+    workspace: Property[bool] = Property.default(True)
+    all_features: Property[bool] = Property.default(True)
     fix: Property[bool] = Property.default(False)
     allow: Property[str | None] = Property.default("staged")
+    deny_warnings: Property[bool] = Property.default(False)
 
     # CargoBuildTask
 
     def get_cargo_command(self, env: dict[str, str]) -> list[str]:
         command = ["cargo", "clippy"]
+        if self.workspace.get():
+            command += ["--workspace"]
+        if self.all_features.get():
+            command += ["--all-features"]
         if self.fix.get():
             command += ["--fix"]
             allow = self.allow.get()
@@ -24,4 +31,7 @@ class CargoClippyTask(CargoBuildTask):
                 command += ["--allow-dirty", "--allow-staged"]
             elif allow is not None:
                 raise ValueError(f"invalid allow: {allow!r}")
+        # must be last, as this argument it passed to cargo check
+        if self.deny_warnings.get():
+            command += ["--", "-D warnings"]
         return command


### PR DESCRIPTION
* `--workspace`, tests whole workspace, important as for non-virtual workspace clippy will lint root crate only
* `--all-features`, tests with all features enabled, important to prevent committing broken code behind a feature flag
* `-- -D warnings`, fail on warnings, should be the default behavior in pipelines

After internal discussions I opted against setting `deny_warnings` to `True` by default, so no "breaking changes" here.  Defaulting to `True` for `--workspace` and `--all-features` thus also won't break anything, and should be set by default, as its absence is basically a foot-gun.