### PR TITLE
add shellcheck

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -36,3 +36,10 @@ type = "fix"
 description = "Fix passing the actual list of tasks to `BuildError` and turn `BuildError.failed_tasks` into `Set[Task]` from `Set[str]`"
 author = "niklas.rosenstein@helsing.ai"
 component = "kraken-build"
+
+[[entries]]
+id = "dd66c076-e8c7-4680-8036-3f30be3c911b"
+type = "feature"
+description = "Add shellcheck capabilities"
+author = "niklas.rosenstein@helsing.ai"
+component = "kraken-build"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -29,3 +29,10 @@ id = "31a52a49-8d26-4dd7-a4bc-84fe9fb37c19"
 type = "improvement"
 description = "Add task to login in all cargo registries"
 author = "quentin.santos@helsing.ai"
+
+[[entries]]
+id = "bc4f2e14-e52b-48ba-b0f3-c1b6210e1682"
+type = "fix"
+description = "Fix passing the actual list of tasks to `BuildError` and turn `BuildError.failed_tasks` into `Set[Task]` from `Set[str]`"
+author = "niklas.rosenstein@helsing.ai"
+component = "kraken-build"

--- a/docs/docs/api/kraken.std.shellcheck.md
+++ b/docs/docs/api/kraken.std.shellcheck.md
@@ -1,0 +1,5 @@
+---
+title: kraken.std.shellcheck
+---
+
+::: kraken.std.shellcheck

--- a/kraken-build/src/kraken/core/system/context.py
+++ b/kraken-build/src/kraken/core/system/context.py
@@ -379,12 +379,7 @@ class Context(MetadataContainer, Currentable["Context"]):
         self.executor.execute_graph(graph, self.observer)
 
         if not graph.is_complete():
-            failed_tasks = list(graph.tasks(failed=True))
-            if len(failed_tasks) == 1:
-                message = f'task "{failed_tasks[0].address}" failed'
-            else:
-                message = "tasks " + ", ".join(f'"{task.address}"' for task in failed_tasks) + " failed"
-            raise BuildError(message)
+            raise BuildError(list(graph.tasks(failed=True)))
 
     @overload
     def listen(

--- a/kraken-build/src/kraken/core/system/errors.py
+++ b/kraken-build/src/kraken/core/system/errors.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from kraken.core.address import Address
+    from kraken.core.system.task import Task
 
     from .project import Project
 
@@ -27,11 +28,17 @@ class ProjectLoaderError(Exception):
 
 
 class BuildError(Exception):
-    def __init__(self, failed_tasks: Iterable[str]) -> None:
+    def __init__(self, failed_tasks: Iterable[Task]) -> None:
+        assert not isinstance(failed_tasks, str), type(failed_tasks)  # type: ignore[unreachable]
+        assert isinstance(failed_tasks, Iterable), type(failed_tasks)
         self.failed_tasks = set(failed_tasks)
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         if len(self.failed_tasks) == 1:
-            return f'task "{next(iter(self.failed_tasks))}" failed'
+            return f'task "{next(iter(self.failed_tasks)).address}" failed'
         else:
-            return "tasks " + ", ".join(f'"{task}"' for task in sorted(self.failed_tasks)) + " failed"
+            return (
+                "tasks "
+                + ", ".join(f'"{task}"' for task in sorted(str(x.address) for x in self.failed_tasks))
+                + " failed"
+            )

--- a/kraken-build/src/kraken/std/shellcheck.py
+++ b/kraken-build/src/kraken/std/shellcheck.py
@@ -1,0 +1,98 @@
+import platform
+import shutil
+import subprocess
+import sys
+from collections.abc import Sequence
+from hashlib import md5
+from pathlib import Path
+from posixpath import basename
+from shutil import copyfileobj
+from tarfile import open as TarFile
+
+from requests import get
+
+from kraken.common import not_none
+from kraken.core import Property, Task, TaskStatus
+
+
+class ShellcheckTask(Task):
+    """Lint one or more Shell scripts with Shellcheck. It can install Shellcheck for you at build time on
+    Linux (arm64, amd64) and OSX (amd64). On other systems, you need to install Shellcheck separately. On OSX,
+    you can install it with Homebrew: `brew install shellcheck`."""
+
+    version: Property[str] = Property.default("0.9.0")
+    url: Property[str | None] = Property.default(None)
+    files: Property[Sequence[str | Path]]
+    skip_on_not_installed: Property[bool] = Property.default(False)
+
+    def get_download_url(self) -> str:
+        if (url := self.url.get()) is not None:
+            return url
+
+        version = self.version.get()
+        match (sys.platform, platform.machine()):
+            case ("linux", "arm64") | ("linux", "x86_64") | ("darwin", "x86_64"):
+                arch_alias = {"x86_64": "x86_64", "arm64": "aarch64"}[platform.machine()]
+                url = (
+                    "https://github.com/koalaman/shellcheck/releases/download/"
+                    f"v{version}/shellcheck-v{version}.{sys.platform}.{arch_alias}.tar.xz"
+                )
+            case _:
+                raise ValueError(
+                    f"cannot install shellcheck for platform {sys.platform}-{platform.machine()}, install it yourself"
+                )
+
+        return url
+
+    def install_shellcheck_from_url(self, url: str) -> str:
+        md5sum = md5(url.encode()).hexdigest()
+        store_path = self.project.context.build_directory / ".store" / md5sum
+        archive_path = store_path / basename(url)
+        bin_path = store_path / "shellcheck"
+
+        if not bin_path.exists():
+            if not archive_path.exists():
+                store_path.mkdir(parents=True, exist_ok=True)
+                self.logger.info("Downloading %s ...", url)
+                try:
+                    with archive_path.open("wb") as fp:
+                        for chunk in get(url, stream=True).iter_content():
+                            fp.write(chunk)
+                except Exception:
+                    archive_path.unlink()
+                    raise
+            self.logger.info("Extracting `%s` from %s ...", bin_path.name, archive_path)
+            with TarFile(archive_path, "r") as tfp:
+                member = next(m for m in tfp.getmembers() if basename(m.name) == "shellcheck")
+                with not_none(tfp.extractfile(member)) as src, bin_path.open("wb") as dst:
+                    copyfileobj(src, dst)
+                bin_path.chmod(0o777)
+
+        return str(bin_path.absolute())
+
+    def execute(self) -> TaskStatus:
+        try:
+            url = self.get_download_url()
+        except ValueError as exc:
+            bin_path = "shellcheck"
+            if not shutil.which(bin_path):
+                status = TaskStatus.skipped if self.skip_on_not_installed.get() else TaskStatus.failed
+                return status(str(exc))
+        else:
+            bin_path = self.install_shellcheck_from_url(url)
+
+        command = [bin_path, *map(str, self.files.get())]
+        return TaskStatus.from_exit_code(
+            command,
+            subprocess.run(command, cwd=self.project.directory).returncode,
+        )
+
+
+def shellcheck(*, name: str = "shellcheck", group: str = "lint", files: Sequence[str]) -> ShellcheckTask:
+    """Create a task to lint the given *files*."""
+
+    from kraken.build import project
+
+    task = project.task(name, ShellcheckTask, group=group)
+    task.files = files
+    return task

--- a/kraken-build/tests/kraken_std/test_shellcheck.py
+++ b/kraken-build/tests/kraken_std/test_shellcheck.py
@@ -1,0 +1,30 @@
+import pytest
+
+from kraken.core import BuildError, Project
+from kraken.std.shellcheck import shellcheck
+
+BAD_SCRIPT = """#!/bin/bash
+if [ -z "$foo"] ; then
+    echo "bar"
+fi
+"""
+
+GOOD_SCRIPT = """#!/bin/bash
+if [ -z "$foo" ]; then
+    echo "bar"
+fi
+"""
+
+
+def test__shellcheck__bad_script(kraken_project: Project) -> None:
+    kraken_project.directory.joinpath("script.sh").write_text(BAD_SCRIPT)
+    shellcheck(files=["script.sh"])
+    with pytest.raises(BuildError) as excinfo:
+        kraken_project.context.execute([":lint"])
+    assert {str(x.address) for x in excinfo.value.failed_tasks} == {":shellcheck"}
+
+
+def test__shellcheck__good_script(kraken_project: Project) -> None:
+    kraken_project.directory.joinpath("script.sh").write_text(GOOD_SCRIPT)
+    shellcheck(files=["script.sh"])
+    kraken_project.context.execute([":lint"])


### PR DESCRIPTION
- fix: Fix passing the actual list of tasks to `BuildError` and turn `BuildError.failed_tasks` into `Set[Task]` from `Set[str]`
- feature: Add shellcheck capabilities
- add kraken.std.shellcheck page
