### PR TITLE
fix: Revert setting credentials providers by default in `.cargo/config.toml` with the `:cargoSyncConfig` task

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "f50c6ea1-ba25-4830-848d-887eabbfb363"
+type = "fix"
+description = "Revert setting credentials providers by default in `.cargo/config.toml` with the `:cargoSyncConfig` task"
+author = "niklas.rosenstein@helsing.ai"


### PR DESCRIPTION
Reverts the changes in https://github.com/kraken-build/kraken/pull/153 that set the `[registry].global-credential-providers` in `.cargo/config.toml` as the default, and instead adds a property that would still allow setting it.

The issue is that in our CI it seems that `libsecret` is not currently available 

```
error: failed to get `xyz` as a dependency of package `abc v0.0.0 (/builds/abc/abc-rs/comments)`
Caused by:
  credential provider `cargo:libsecret` failed action `get`
Caused by:
  failed to load libsecret: try installing the `libsecret` or `libsecret-1-0` package with the system package manager
Caused by:
  libsecret-1.so: cannot open shared object file: No such file or directory
```

I also am not sure if we should set this in a project's `.cargo/config.toml`; these settings might be more appropriate in the user's global configuration (`$CARGO_HOME/config.toml`).