### PR TITLE
Fix DaemonController keeping the fork alive when it fails to start the daemon process

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "654174ac-b3d2-476a-b761-e65c8f4dd8a5"
+type = "fix"
+description = "Fixed an issue where when the DaemonController fails to start the daemon process, the fork of the Kraken process continues, resulting in two copies of the process trying to run to completion, e.g. executing tasks from this point on."
+author = "niklas.rosenstein@helsing.ai"


### PR DESCRIPTION
I ran into an issue where it couldn't find `mitmweb` and then I ended up with all tasks executed twice. That was very confusing and difficult to debug!