### PR TITLE
fix: Fix that `pyproject.toml` is continuously outdated in certain cases

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "a2e6c3ac-b166-4287-9f74-d79dbd499205"
+type = "fix"
+description = "Fix that updating the `pyproject.toml` is continuously outdated in certain cases"
+author = "niklas.rosenstein@helsing.ai"

--- a/kraken-build/src/kraken/std/python/pyproject.py
+++ b/kraken-build/src/kraken/std/python/pyproject.py
@@ -79,6 +79,13 @@ class Pyproject(MutableMapping[str, Any]):
     def __delitem__(self, key: str) -> None:
         del self.data[key]
 
+    def setdefault(self, key: str, default: Any) -> Any:
+        # NOTE(@niklas): We need to override this as the default implementation from MutableMapping is not
+        #       compatible with the expected behaviour from the wrapped Tomlkit container. See
+        #       https://github.com/sdispater/tomlkit/issues/49#issuecomment-1999713939
+        self.data.setdefault(key, default)
+        return self.data[key]
+
     @classmethod
     def read_string(cls, text: str) -> Pyproject:
         return cls(None, tomlkit.parse(text))

--- a/kraken-build/src/kraken/std/python/pyproject.py
+++ b/kraken-build/src/kraken/std/python/pyproject.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Iterator, MutableMapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -64,14 +64,20 @@ class Pyproject(MutableMapping[str, Any]):
         self.path = path
         self.data = data
 
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.data)
+
+    def __len__(self) -> int:
+        return len(self.data)
+
     def __getitem__(self, key: str) -> Any:
         return self.data[key]
 
     def __setitem__(self, key: str, value: Any) -> None:
         self.data[key] = value
 
-    def setdefault(self, key: str, value: Any) -> Any:
-        return self.data.setdefault(key, value)
+    def __delitem__(self, key: str) -> None:
+        del self.data[key]
 
     @classmethod
     def read_string(cls, text: str) -> Pyproject:

--- a/kraken-build/src/kraken/std/python/pyproject.py
+++ b/kraken-build/src/kraken/std/python/pyproject.py
@@ -79,7 +79,7 @@ class Pyproject(MutableMapping[str, Any]):
     def __delitem__(self, key: str) -> None:
         del self.data[key]
 
-    def setdefault(self, key: str, default: Any) -> Any:
+    def setdefault(self, key: str, default: Any | None = None) -> Any:
         # NOTE(@niklas): We need to override this as the default implementation from MutableMapping is not
         #       compatible with the expected behaviour from the wrapped Tomlkit container. See
         #       https://github.com/sdispater/tomlkit/issues/49#issuecomment-1999713939


### PR DESCRIPTION
Sometimes the `pyproject.toml` would add or remove some newlines, in certain cases also be continuously outdated, never satisfying the `pyproject.check` task. This is because we converted the top-level `tomlkit` container that keeps track of formatting to a standard Python `dict`.