### PR TITLE
fix: Pass the PEX-built `pycln` binary also to the Pycln format task (was only passed to the check variant)

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "49b2f413-5962-4376-9f48-d25355b99955"
+type = "fix"
+description = "Pass the PEX-built `pycln` binary also to the Pycln format task (was only passed to the check variant)"
+author = "niklas.rosenstein@helsing.ai"

--- a/kraken-build/src/kraken/std/python/tasks/pycln_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pycln_task.py
@@ -68,4 +68,5 @@ def pycln(*, name: str = "python.pycln", project: Project | None = None, version
     check_task.pycln_bin = pycln_bin
     check_task.check_only = True
     format_task = project.task(name, PyclnTask, group="fmt")
+    format_task.pycln_bin = pycln_bin
     return PyclnTasks(check_task, format_task)


### PR DESCRIPTION
We forgot to pass the Pex-built `pycln` binary to the `python.pycln` task!