### PR TITLE
fix: Fixed dictionary keys changed during iteration" error in `PoetryPyprojectHandler.set_path_dependencies_to_version()` which seems to be caused by `tomlkit` even when modifying an existing key but setting it to a different value/type

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "f39ed8fc-360e-4b63-88ab-305f8b788555"
+type = "fix"
+description = "Fixed dictionary keys changed during iteration\" error in `PoetryPyprojectHandler.set_path_dependencies_to_version()` which seems to be caused by `tomlkit` even when modifying an existing key but setting it to a different value/type"
+author = "niklas.rosenstein@helsing.ai"

--- a/kraken-build/src/kraken/std/python/buildsystem/__init__.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/__init__.py
@@ -86,17 +86,19 @@ class PythonBuildSystem(abc.ABC):
         pyproject.set_version(version)
         pyproject.raw.save()
 
-        sum_replaced = 0
         for package in pyproject.get_packages():
             package_dir = self.project_directory / (package.from_ or "") / package.include
+
+            sum_replaced = 0
             for path, n_replaced in update_python_version_str_in_source_files(version, package_dir):
                 sum_replaced += n_replaced
                 revert_files[path] = path.read_text()
 
-            print(
-                f"Bumped {sum_replaced} version reference(s) in {len(revert_files)} files(s) in directory",
-                f"{package_dir.relative_to(self.project_directory)} to {version}",
-            )
+            if sum_replaced > 0:
+                print(
+                    f"Bumped {sum_replaced} version reference(s) in {len(revert_files)} files(s) in directory",
+                    f"{package_dir.relative_to(self.project_directory)} to {version}",
+                )
 
         print("Modified files:")
         for path in sorted(revert_files):

--- a/kraken-build/src/kraken/std/python/buildsystem/poetry.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/poetry.py
@@ -121,7 +121,7 @@ class PoetryPyprojectHandler(PyprojectHandler):
                 yield "group.dev.dependencies", group_dev_dependencies
 
         for name, dependencies in _dependency_groups():
-            for key, value in dependencies.items():
+            for key, value in list(dependencies.items()):
                 if isinstance(value, dict) and "path" in value:
                     logger.debug("Replacing path dependency %s with version %s in %s", key, version, name)
                     dependencies[key] = version


### PR DESCRIPTION
It seems `tomlkit` containers behave a bit differently in that you can't even update an existing key's value during iteration. The following snippet demonstrates what caused this bug:

```py
import tomlkit

data = tomlkit.loads("""
[package]
version = "1.0"
""")

for key in data.keys():
    data[key] = "bar"
```

