### PR TITLE
feature: Expose the locked property in CargoBuildTask

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "5a4c9349-429d-4594-805b-404ed45020c3"
+type = "improvement"
+description = "Expose the `locked` property of `CargoBuildTask` via the `cargo_build` helper function"
+author = "uluc.sengil@helsing.ai"

--- a/kraken-build/src/kraken/std/cargo/__init__.py
+++ b/kraken-build/src/kraken/std/cargo/__init__.py
@@ -321,6 +321,7 @@ def cargo_build(
     project: Project | None = None,
     features: list[str] | None = None,
     depends_on: Sequence[Task] = (),
+    locked: bool | None = None,
 ) -> CargoBuildTask:
     """Creates a task that runs `cargo build`.
 
@@ -359,6 +360,7 @@ def cargo_build(
     task.incremental = incremental
     task.target = mode
     task.additional_args = additional_args
+    task.locked = locked
     task.env = Supplier.of_callable(lambda: {**cargo.build_env, **(env or {})})
 
     task.depends_on(f":{CARGO_BUILD_SUPPORT_GROUP_NAME}?")


### PR DESCRIPTION
The CargoBuildTask has a `locked` property to configure its interaction with `Cargo.lock` files, but it is not exposed through the `cargo_build` function which is more widely used. This change adds `locked` to `cargo_build` as an optional keyword argument