### PR TITLE
bugfix(?): Write user-provided generated .gitignore content after the API-provided content

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,4 +1,10 @@
 [[entries]]
+id = "251fc70d-a665-448a-9c07-42794342129a"
+type = "improvement"
+description = "Move generated .gitignore around so user-provided definitions can overwrite API-provided ones"
+author = "uluc.sengil@helsing.ai"
+
+[[entries]]
 id = "5a4c9349-429d-4594-805b-404ed45020c3"
 type = "improvement"
 description = "Expose the `locked` property of `CargoBuildTask` via the `cargo_build` helper function"

--- a/kraken-build/src/kraken/std/git/tasks/sync_task.py
+++ b/kraken-build/src/kraken/std/git/tasks/sync_task.py
@@ -53,11 +53,13 @@ class GitignoreSyncTask(RenderFileTask):
             user1, user2 = user2, user1
 
         # Replace the generated content.
-        generated = GitignoreFile.parse(self.generated_content.get())
+        generated = GitignoreFile()
         if tokens := self.gitignore_io_tokens.get():
             generated += GitignoreFile.parse(
                 gitignore_io_fetch_cached(tokens, backfill=self.gitignore_io_allow_http_request_backfill.get())
             )
+        # User-provided generated content, allowing for overrides to API-generated content.
+        generated += GitignoreFile.parse(self.generated_content.get())
 
         # Ensure there's at least one blank space between sections.
         if user1 and generated and (user1[-1] != "" and generated[0] != ""):


### PR DESCRIPTION
The GitignoreSync task pulls `.gitignore` data from three different sources: From the user, build process-defined `generated_content` and API-provided `gitignore_io_tokens`. This change prints `generated_content` after `gitignore_io_tokens`, allowing build setups to overwrite API-provided content (for example, adding `!Cargo.lock` to `generated_content` to allow users to commit Cargo lockfiles by overriding the API-provided Rust `.gitignore`)