### PR TITLE
hygiene: `CargoManifest.read()` now raises a `ValueError` if the manifest has neither a `[package]` nor a `[workspace]` section rather than a `pydantic.ClassError`

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -21,3 +21,9 @@ id = "bc473819-4740-43ac-a86a-ce98b8039041"
 type = "improvement"
 description = "update dependency httpx to ^0.27.0"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "367b2d48-8515-4846-8ec7-3a3b3d5a9483"
+type = "hygiene"
+description = "`CargoManifest.read()` now raises a `ValueError` if the manifest has neither a `[package]` nor a `[workspace]` section rather than a `pydantic.ClassError`"
+author = "@NiklasRosenstein"

--- a/kraken-build/src/kraken/std/cargo/manifest.py
+++ b/kraken-build/src/kraken/std/cargo/manifest.py
@@ -13,7 +13,6 @@ from typing import Any
 
 import tomli
 import tomli_w
-from pydantic import ClassError
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +239,7 @@ class CargoManifest:
         with path.open("rb") as fp:
             ret = cls.of(path, tomli.load(fp))
             if ret.package is None and ret.workspace is None:
-                raise ClassError
+                raise ValueError("Cargo manifest must have either a package or a workspace section.")
             return ret
 
     @classmethod

--- a/kraken-build/tests/kraken_std/test_cargo_manifest.py
+++ b/kraken-build/tests/kraken_std/test_cargo_manifest.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-from pydantic import ClassError
 
 from kraken.std.cargo.manifest import CargoManifest
 
@@ -89,9 +88,9 @@ def test_cargo_manifest_workspace_file() -> None:
 def test_cargo_manifest_throws_when_no_workspace_or_package() -> None:
     """
     This test ensures that when we read a file missing both a Package section and a Workspace section, it
-    throws a ClassError.
+    throws a ValueError.
     """
 
     cargo_file = Path(__file__).parent / "data" / "invalid_manifest.toml"
-    with pytest.raises(ClassError):
+    with pytest.raises(ValueError):
         CargoManifest.read(cargo_file)


### PR DESCRIPTION
I got no clue how this got in here but according to blame this was in even before `kraken-std` was merged with `kraken-core`.