### PR TITLE
fix: inject version for path dependencies in workspace virtual manifests

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "1fddba58-dd61-4906-baca-f1a41e3b534f"
+type = "fix"
+description = "inject version for path dependencies in workspace virtual manifests"
+author = "tom.karwowski@helsing.ai"

--- a/kraken-build/src/kraken/std/cargo/manifest.py
+++ b/kraken-build/src/kraken/std/cargo/manifest.py
@@ -6,13 +6,14 @@ import json
 import logging
 import os
 import subprocess
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any
 
 import tomli
 import tomli_w
+from deprecated import deprecated
 
 logger = logging.getLogger(__name__)
 
@@ -21,15 +22,20 @@ logger = logging.getLogger(__name__)
 class Bin:
     name: str
     path: str
-    _remainder: dict[str, Any]
+    _raw: dict[str, Any]
 
     def to_json(self) -> dict[str, Any]:
-        return {"name": self.name, "path": self.path, **self._remainder}
+        return self._raw
 
     @staticmethod
     def from_json(data: dict[str, Any]) -> Bin:
         data = dict(data)
-        return Bin(data.pop("name"), data.pop("path"), _remainder=data)
+        return Bin(data.get("name", ""), data.get("path", ""), _raw=data)
+
+    @property
+    @deprecated(reason="use Bin._raw instead", version="0.37.0")
+    def _remainder(self) -> dict[str, Any]:
+        return self._raw
 
 
 # TODO: Differentiate between lib kinds?
@@ -63,7 +69,7 @@ class WorkspaceMember:
 @dataclass
 class CargoMetadata:
     _path: Path
-    _data: dict[str, Any]
+    _raw: dict[str, Any]
 
     workspaceMembers: list[WorkspaceMember]
     artifacts: list[Artifact]
@@ -144,70 +150,81 @@ class CargoMetadata:
 
         return cls(path, data, workspace_members, artifacts, Path(data["target_directory"]))
 
+    @property
+    @deprecated(reason="use CargoMetadata._raw instead", version="0.37.0")
+    def _data(self) -> dict[str, Any]:
+        return self._raw
+
 
 @dataclass
 class Package:
     name: str
     version: str | None
     edition: str | None
-    unhandled: dict[str, Any] | None
+    _raw: dict[str, Any]
 
     @classmethod
-    def from_json(cls, json: dict[str, str]) -> Package:
-        cloned = dict(json)
-        name = cloned.pop("name")
-        version = cloned.pop("version", None)
-        edition = cloned.pop("edition", None)
-        return Package(name, version, edition, cloned)
+    def from_json(cls, json: dict[str, Any]) -> Package:
+        _raw = dict(json)
+        name = _raw.get("name", "")
+        version = _raw.get("version", None)
+        edition = _raw.get("edition", None)
+        return Package(name, version, edition, _raw)
 
-    def to_json(self) -> dict[str, str]:
-        values = {f.name: getattr(self, f.name) for f in fields(self) if f.name != "unhandled"}
-        if self.unhandled is not None:
-            values.update({k: v for k, v in self.unhandled.items() if v is not None})
-        return {k: v for k, v in values.items() if v is not None}
+    def to_json(self) -> dict[str, Any]:
+        return {k: v for k, v in self._raw.items() if v is not None}
+
+    @property
+    @deprecated(reason="use Package._raw instead", version="0.37.0")
+    def unhandled(self) -> dict[str, Any]:
+        return self._raw
 
 
 @dataclass
 class WorkspacePackage:
     version: str
-    unhandled: dict[str, Any] | None
+    _raw: dict[str, Any]
 
     @classmethod
-    def from_json(cls, json: dict[str, str]) -> WorkspacePackage:
+    def from_json(cls, json: dict[str, Any]) -> WorkspacePackage:
         cloned = dict(json)
-        version = cloned.pop("version")
+        version = cloned.get("version", "")
         return WorkspacePackage(version, cloned)
 
-    def to_json(self) -> dict[str, str]:
-        values = {f.name: getattr(self, f.name) for f in fields(self) if f.name != "unhandled"}
-        if self.unhandled is not None:
-            values.update({k: v for k, v in self.unhandled.items() if v is not None})
-        return {k: v for k, v in values.items() if v is not None}
+    def to_json(self) -> dict[str, Any]:
+        return {k: v for k, v in self._raw.items() if v is not None}
+
+    @property
+    @deprecated(reason="use WorkspacePackage._raw instead", version="0.37.0")
+    def unhandled(self) -> dict[str, Any]:
+        return self._raw
 
 
 @dataclass
 class Workspace:
     package: WorkspacePackage | None
     members: list[str] | None
-    unhandled: dict[str, Any] | None
+    dependencies: Dependencies | None
+    build_dependencies: Dependencies | None
+    _raw: dict[str, Any]
 
     @classmethod
     def from_json(cls, json: dict[str, Any]) -> Workspace:
-        cloned = dict(json)
         return Workspace(
-            WorkspacePackage.from_json(cloned.pop("package")) if "package" in cloned else None,
-            cloned.pop("members") if "members" in cloned else None,
-            cloned,
+            WorkspacePackage.from_json(json["package"]) if "package" in json else None,
+            json.get("members"),
+            Dependencies.from_json(json["dependencies"]) if "dependencies" in json else None,
+            Dependencies.from_json(json["build-dependencies"]) if "build-dependencies" in json else None,
+            json,
         )
 
     def to_json(self) -> dict[str, Any]:
-        values = {
-            "package": self.package.to_json() if self.package else None,
-            "members": self.members if self.members else None,
-        }
-        if self.unhandled is not None:
-            values.update({k: v for k, v in self.unhandled.items() if v is not None})
-        return {k: v for k, v in values.items() if v is not None}
+        return {k: v for k, v in self._raw.items() if v is not None}
+
+    @property
+    @deprecated(reason="use Workspace._raw instead", version="0.37.0")
+    def unhandled(self) -> dict[str, Any]:
+        return self._raw
 
 
 @dataclass
@@ -226,7 +243,7 @@ class Dependencies:
 @dataclass
 class CargoManifest:
     _path: Path
-    _data: dict[str, Any]
+    _raw: dict[str, Any]
 
     package: Package | None
     workspace: Workspace | None
@@ -255,7 +272,7 @@ class CargoManifest:
         )
 
     def to_json(self) -> dict[str, Any]:
-        result = self._data.copy()
+        result = self._raw.copy()
         if self.bin:
             result["bin"] = [x.to_json() for x in self.bin]
         else:
@@ -277,3 +294,8 @@ class CargoManifest:
         path = path or self._path
         with path.open("wb") as fp:
             tomli_w.dump(self.to_json(), fp)
+
+    @property
+    @deprecated(reason="use CargoManifest._raw instead", version="0.37.0")
+    def _data(self) -> dict[str, Any]:
+        return self._raw

--- a/kraken-build/src/kraken/std/cargo/tasks/cargo_publish_task.py
+++ b/kraken-build/src/kraken/std/cargo/tasks/cargo_publish_task.py
@@ -19,7 +19,7 @@ class CargoPublishTask(CargoBuildTask):
     #: Path to the Cargo configuration file (defaults to `.cargo/config.toml`).
     cargo_config_file: Property[Path] = Property.default(".cargo/config.toml")
 
-    #: Name of the package to publish (only requried for publishing packages from workspace)
+    #: Name of the package to publish (only required for publishing packages from workspace)
     package_name: Property[str | None] = Property.default(None)
 
     #: The registry to publish the package to.
@@ -85,6 +85,17 @@ class CargoPublishTask(CargoBuildTask):
                 self._push_version_to_path_deps(fixed_version_string, manifest.dependencies.data, registry.alias)
             if manifest.build_dependencies:
                 self._push_version_to_path_deps(fixed_version_string, manifest.build_dependencies.data, registry.alias)
+
+            if manifest.workspace:
+                if manifest.workspace.dependencies:
+                    self._push_version_to_path_deps(
+                        fixed_version_string, manifest.workspace.dependencies.data, registry.alias
+                    )
+                if manifest.workspace.build_dependencies:
+                    self._push_version_to_path_deps(
+                        fixed_version_string, manifest.workspace.build_dependencies.data, registry.alias
+                    )
+
         return manifest.to_toml_string()
 
     def _push_version_to_path_deps(

--- a/kraken-build/tests/kraken_std/data/workspace_manifest.toml
+++ b/kraken-build/tests/kraken_std/data/workspace_manifest.toml
@@ -1,2 +1,8 @@
 [workspace]
 members = ["crates/*"]
+
+[workspace.dependencies]
+subcrate.path = "./subcrate"
+
+[workspace.build-dependencies]
+other_subcrate.path = "./other_subcrate"

--- a/kraken-build/tests/kraken_std/test_cargo_manifest.py
+++ b/kraken-build/tests/kraken_std/test_cargo_manifest.py
@@ -25,10 +25,10 @@ def test_cargo_manifest_handles_unknown_fields_correctly() -> None:
     assert manifest.package.version == "0.1.2"
     assert manifest.package.edition == "2021"
 
-    assert manifest.package.unhandled is not None
-    assert len(manifest.package.unhandled) == 2
-    assert len(manifest.package.unhandled["include"]) == 2
-    assert manifest.package.unhandled["authors"] == ["author1", "author2"]
+    assert manifest.package._raw is not None
+    assert len(manifest.package._raw) == 5
+    assert len(manifest.package._raw["include"]) == 2
+    assert manifest.package._raw["authors"] == ["author1", "author2"]
 
 
 def test_cargo_manifest_writes_json_correctly() -> None:
@@ -61,13 +61,13 @@ def test_cargo_manifest_complex_file() -> None:
 
     assert manifest is not None
     assert manifest.package is not None
-    assert manifest.package.unhandled is not None
-    assert len(manifest.package.unhandled) > 0
+    assert manifest.package._raw is not None
+    assert len(manifest.package._raw) > 0
     assert manifest.package.name == "rand"
     assert manifest.package.edition == "2018"
     assert manifest.package.version == "0.8.5"
-    assert manifest.package.unhandled["include"] == ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
-    assert manifest.package.unhandled["autobenches"]
+    assert manifest.package._raw["include"] == ["src/", "LICENSE-*", "README.md", "CHANGELOG.md", "COPYRIGHT"]
+    assert manifest.package._raw["autobenches"]
 
 
 def test_cargo_manifest_workspace_file() -> None:
@@ -83,6 +83,10 @@ def test_cargo_manifest_workspace_file() -> None:
     assert manifest.workspace is not None
     assert manifest.workspace.members is not None
     assert manifest.workspace.members == ["crates/*"]
+    assert manifest.workspace.dependencies is not None
+    assert manifest.workspace.dependencies.data == {"subcrate": {"path": "./subcrate"}}
+    assert manifest.workspace.build_dependencies is not None
+    assert manifest.workspace.build_dependencies.data == {"other_subcrate": {"path": "./other_subcrate"}}
 
 
 def test_cargo_manifest_throws_when_no_workspace_or_package() -> None:


### PR DESCRIPTION
There was an unhandled case in version injection task.

For a project with virtual manifest like this:
```
# in /Cargo.toml

[workspace.dependencies]
subcrate = { path = "./subcrate" }
```
Kraken would not inject `version` and `registry` attributes.

This MR fixes it, by correctly injecting versions for dependencies declared in workspaces with virtual manifest.

Decisions:

- Add `_raw` attribute to most manifest related classes, store raw JSON data there (without removing the handled fields)
- For fields that already had a subset of this, rename the field to `_raw` and use a getter with deprecation warning for backward compatibility
- All `to_json` methods could be simplified, as they can simply return `self._raw`