### PR TITLE
Make it possible for Kraken to handle PyPI

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "e6f6ee7b-e382-44f1-84b8-a24ad01c5d24"
+type = "hygiene"
+description = "Make it possible for Kraken to handle PyPI"
+author = "quentin.santos@helsing.ai"

--- a/kraken-build/src/kraken/std/python/buildsystem/poetry.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/poetry.py
@@ -97,13 +97,13 @@ class PoetryPyprojectHandler(PyprojectHandler):
                 logger.warning(
                     "Poetry does not support disabling SSL verification for indexes (source: %s)", index.alias
                 )
-            sources.append(
-                {
-                    "name": index.alias,
-                    "url": index.index_url,
-                    "priority": index.priority.value,
-                }
-            )
+            package = {
+                "name": index.alias,
+                "priority": index.priority.value,
+            }
+            if index.index_url is not None:
+                package["url"] = index.index_url
+            sources.append(package)
 
     def set_path_dependencies_to_version(self, version: str) -> None:
         """

--- a/kraken-build/src/kraken/std/python/pyproject.py
+++ b/kraken-build/src/kraken/std/python/pyproject.py
@@ -41,7 +41,7 @@ class PackageIndex:
     alias: str
 
     #: The URL to find the packages at.
-    index_url: str
+    index_url: str | None
 
     #: The priority of the index. Not all tools support it exactly how we model it in here (e.g. like Poetry),
     #: so the corresponding #PyprojectHandler implementation may need to do some translation.

--- a/kraken-build/src/kraken/std/python/settings.py
+++ b/kraken-build/src/kraken/std/python/settings.py
@@ -105,16 +105,16 @@ class PythonSettings:
                 raise ValueError(f"cannot add another default index (got: {defidx.alias!r}, trying to add: {alias!r})")
 
         if index_url is None:
-            if alias == "pypi":
+            if alias.lower() == "pypi":
                 index_url = None
-            elif alias == "testpypi":
+            elif alias.lower() == "testpypi":
                 index_url = "https://test.pypi.org/simple"
             else:
                 raise ValueError(f"cannot derive index URL for alias {alias!r}")
         if upload_url is None:
-            if alias == "pypi":
+            if alias.lower() == "pypi":
                 upload_url = "https://upload.pypi.org/legacy"
-            elif alias == "testpypi":
+            elif alias.lower() == "testpypi":
                 upload_url = "https://test.pypi.org/legacy"
             elif index_url.endswith("/simple"):
                 upload_url = index_url[: -len("/simple")]

--- a/kraken-build/src/kraken/std/python/settings.py
+++ b/kraken-build/src/kraken/std/python/settings.py
@@ -106,7 +106,7 @@ class PythonSettings:
 
         if index_url is None:
             if alias == "pypi":
-                index_url = "https://pypi.org/simple"
+                index_url = None
             elif alias == "testpypi":
                 index_url = "https://test.pypi.org/simple"
             else:


### PR DESCRIPTION
Explicitly listing PyPI as a package index with an URL results in the error below. This PR sets the `index_url` of the package indexes whose aliases matches `pypi` to `None`. This requires another change to handle this `None` value properly.

```
The PyPI repository cannot be configured with a custom url.
```