### PR TITLE
Update manifest.py

### DIFF
--- a/kraken-build/src/kraken/std/cargo/manifest.py
+++ b/kraken-build/src/kraken/std/cargo/manifest.py
@@ -277,3 +277,6 @@ class CargoManifest:
         path = path or self._path
         with path.open("wb") as fp:
             tomli_w.dump(self.to_json(), fp)
+
+    def get_from_raw_data(self, name: str) -> Any:
+            return self._data[name]


### PR DESCRIPTION
Allow reading cargo.toml configuration from private CargoManifest._data. This will increase the flexibility of `CargoManifest`. For example if a package has conditional target dependencies, currently we cannot access them.