### PR TITLE
Remove most deprecated APIs

### DIFF
--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -1,0 +1,6 @@
+[[entries]]
+id = "602b5b4d-4b83-4234-8d32-033c93307912"
+type = "breaking change"
+description = "Remove a lot of long deprecated APIs"
+author = "@NiklasRosenstein"
+pr = "https://github.com/kraken-build/kraken/pull/268"

--- a/kraken-build/src/kraken/core/system/context.py
+++ b/kraken-build/src/kraken/core/system/context.py
@@ -210,7 +210,7 @@ class Context(MetadataContainer, Currentable["Context"]):
 
     def resolve_tasks(
         self,
-        addresses: Sequence[Task | str | Address] | None,
+        addresses: Iterable[Task | str | Address] | None,
         relative_to: Project | Address | None = None,
         set_selected: bool = False,
     ) -> list[Task]:

--- a/kraken-build/src/kraken/core/system/project.py
+++ b/kraken-build/src/kraken/core/system/project.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 import warnings
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
 
@@ -12,7 +12,7 @@ from kraken.core.address import Address
 from kraken.core.base import Currentable, MetadataContainer
 from kraken.core.system.kraken_object import KrakenObject
 from kraken.core.system.property import Property
-from kraken.core.system.task import GroupTask, Task, TaskSet
+from kraken.core.system.task import GroupTask, Task
 
 if TYPE_CHECKING:
     from kraken.core.system.context import Context
@@ -384,30 +384,3 @@ class Project(KrakenObject, MetadataContainer, Currentable["Project"]):
             task.default = default
 
         return task
-
-    ##
-    # Begin: Deprecated APIs
-    ##
-
-    @property
-    @deprecated(reason="Project.path is deprecated, use str(Project.address) instead")
-    def path(self) -> str:
-        """Returns the path that uniquely identifies the project in the current build context."""
-
-        return str(self.address)
-
-    @deprecated(reason="Project.resolve_tasks() is deprecated, use Project.context.resolve_tasks() instead.")
-    def resolve_tasks(self, tasks: str | Task | Iterable[str | Task]) -> TaskSet:
-        """Resolve tasks relative to the current project."""
-
-        if isinstance(tasks, (str, Task)):
-            tasks = [tasks]
-
-        result = TaskSet()
-        for item in tasks:
-            if isinstance(item, str):
-                result.add(self.context.resolve_tasks([item], self), partition=item)
-            else:
-                result.add([item])
-
-        return result

--- a/kraken-build/src/kraken/core/system/project_test.py
+++ b/kraken-build/src/kraken/core/system/project_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from kraken.core.system.project import Project
 from kraken.core.system.property import Property
-from kraken.core.system.task import Task, VoidTask
+from kraken.core.system.task import Task, TaskSet, VoidTask
 
 
 @dataclass
@@ -14,7 +14,9 @@ class MyDescriptor:
 
 def test__Project__resolve_outputs__can_find_dataclass_in_metadata(kraken_project: Project) -> None:
     kraken_project.task("carrier", VoidTask).outputs.append(MyDescriptor("foobar"))
-    assert list(kraken_project.resolve_tasks(":carrier").select(MyDescriptor).all()) == [MyDescriptor("foobar")]
+    assert list(TaskSet(kraken_project.context.resolve_tasks(":carrier")).select(MyDescriptor).all()) == [
+        MyDescriptor("foobar")
+    ]
 
 
 def test__Project__resolve_outputs__can_find_dataclass_in_properties(kraken_project: Project) -> None:
@@ -25,7 +27,9 @@ def test__Project__resolve_outputs__can_find_dataclass_in_properties(kraken_proj
 
     task = kraken_project.task("carrier", MyTask)
     task.out_prop = MyDescriptor("foobar")
-    assert list(kraken_project.resolve_tasks(":carrier").select(MyDescriptor).all()) == [MyDescriptor("foobar")]
+    assert list(TaskSet(kraken_project.context.resolve_tasks(":carrier")).select(MyDescriptor).all()) == [
+        MyDescriptor("foobar")
+    ]
 
 
 def test__Project__resolve_outputs__can_not_find_input_property(kraken_project: Project) -> None:
@@ -36,7 +40,7 @@ def test__Project__resolve_outputs__can_not_find_input_property(kraken_project: 
 
     task = kraken_project.task("carrier", MyTask)
     task.out_prop = MyDescriptor("foobar")
-    assert list(kraken_project.resolve_tasks(":carrier").select(MyDescriptor).all()) == []
+    assert list(TaskSet(kraken_project.context.resolve_tasks(":carrier")).select(MyDescriptor).all()) == []
 
 
 def test__Project__resolve_outputs_supplier(kraken_project: Project) -> None:
@@ -47,7 +51,9 @@ def test__Project__resolve_outputs_supplier(kraken_project: Project) -> None:
 
     task = kraken_project.task("carrier", MyTask)
     task.out_prop = MyDescriptor("foobar")
-    assert kraken_project.resolve_tasks(":carrier").select(MyDescriptor).supplier().get() == [MyDescriptor("foobar")]
+    assert TaskSet(kraken_project.context.resolve_tasks(":carrier")).select(MyDescriptor).supplier().get() == [
+        MyDescriptor("foobar")
+    ]
 
 
 def test__Project__do_normalizes_taskname_backwards_compatibility_pre_0_12_0(kraken_project: Project) -> None:
@@ -69,4 +75,4 @@ def test__Project__do__does_not_set_property_on_None_value(kraken_project: Proje
         def execute(self) -> None: ...
 
     kraken_project.task("carrier", MyTask)
-    assert kraken_project.resolve_tasks(":carrier").select(str).supplier().get() == []
+    assert TaskSet(kraken_project.context.resolve_tasks(":carrier")).select(str).supplier().get() == []

--- a/kraken-build/src/kraken/core/system/property.py
+++ b/kraken-build/src/kraken/core/system/property.py
@@ -21,7 +21,6 @@ from operator import concat
 from pathlib import Path
 from typing import Any, ClassVar, TypeVar, cast
 
-import deprecated
 from typeapi import (
     AnnotatedTypeHint,
     ClassTypeHint,
@@ -142,27 +141,6 @@ class Property(Supplier[T]):
         """Assign the result of this function as a default value to a property to declare it's default factory."""
 
         return PropertyConfig(default_factory=func, help=help)
-
-    @staticmethod
-    @deprecated.deprecated(reason="use Property.required(), .default() or .default_factory() instead")
-    def config(
-        output: bool = False,
-        default: Any | NotSet = NotSet.Value,
-        default_factory: Callable[[], Any] | NotSet = NotSet.Value,
-    ) -> Any:
-        """Assign the result of this function as a default value to a property on the class level of an :class:`Object`
-        subclass to configure it's default value or whether it is an output property. This is an alternative to using
-        a :class:`typing.Annotated` type hint.
-
-        .. code:: Example
-
-            from kraken.core.system.property import Object, Property, config
-
-            class MyObj(Object):
-                a: Property[int] = config(default=42)
-        """
-
-        return PropertyConfig(output, default, default_factory)
 
     def __init__(
         self,

--- a/kraken-build/src/kraken/core/system/task.py
+++ b/kraken-build/src/kraken/core/system/task.py
@@ -10,7 +10,7 @@ import dataclasses
 import enum
 import logging
 import shlex
-from collections.abc import Collection, Iterable, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ForwardRef, Generic, Literal, TypeVar, cast, overload
 
@@ -235,57 +235,10 @@ class Task(KrakenObject, PropertyContainer, abc.ABC):
         assert isinstance(self._parent, Project), "Task.parent must be a Project"
         return self._parent
 
-    ###
-    # Begin: Deprecated APIs
-    ###
-
-    @property
-    @deprecated(reason="Task.path is deprecated, use str(Task.address) instead.")
-    def path(self) -> str:
-        return str(self.address)
-
     @property
     @deprecated(reason="Task.outputs is deprecated.")
     def outputs(self) -> list[Any]:
         return self._outputs
-
-    @deprecated(reason="Task.add_relationship() is deprecated, use Task.depends_on() or Task.required_by() instead.")
-    def add_relationship(
-        self,
-        task_or_selector: Task | Sequence[Task | Address] | Address | str,
-        strict: bool = True,
-        inverse: bool = False,
-    ) -> None:
-        """Add a relationship to this task that will be returned by :meth:`get_relationships`.
-
-        :param task_or_selector: A task, list of tasks or a task selector (wich may expand to multiple tasks)
-            to add as a relationship to this task. If a task selector string is specified, it will be evaluated
-            lazily when :meth:`get_relationships` is called.
-        :param strict: Whether the relationship is strict, i.e. informs a strong dependency in one or the other
-            direction. If a relationship is not strict, it informs only order of execution and parallel
-            exclusivity.
-        :param inverse: Whether to invert the relationship.
-        """
-
-        if isinstance(task_or_selector, (Task, str)):
-            if isinstance(task_or_selector, str):
-                task_or_selector = Address(task_or_selector)
-            self.__relationships.append(_Relationship(task_or_selector, strict, inverse))
-        elif isinstance(task_or_selector, Sequence):
-            for idx, task in enumerate(task_or_selector):
-                if not isinstance(task, Task):
-                    raise TypeError(
-                        f"task_or_selector[{idx}] must be Task | Sequence[Task] | str, got "
-                        f"{type(task_or_selector).__name__}"
-                    )
-            for task in task_or_selector:
-                if isinstance(task, str):
-                    task = Address(task)
-                self.__relationships.append(_Relationship(task, strict, inverse))
-        else:
-            raise TypeError(
-                f"task_or_selector argument must be Task | Sequence[Task] | str, got {type(task_or_selector).__name__}"
-            )
 
     def add_tag(self, name: str, *, reason: str, origin: str | None = None) -> None:
         """

--- a/kraken-build/src/kraken/std/dist.py
+++ b/kraken-build/src/kraken/std/dist.py
@@ -231,7 +231,7 @@ def dist(
         k: databind.json.load(v, IndividualDistOptions) if not isinstance(v, IndividualDistOptions) else v
         for k, v in dependencies.items()
     }
-    dependencies_set = project.resolve_tasks(dependencies_map)
+    dependencies_set = TaskSet(project.context.resolve_tasks(dependencies_map, project))
 
     # This associates the IndividualDistOptions specified in *dependencies* to the Resource(s)
     # provided by the task(s).

--- a/kraken-build/src/kraken/std/python/tasks/base_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/base_task.py
@@ -7,7 +7,6 @@ import subprocess as sp
 import sys
 from collections.abc import Iterable, MutableMapping
 
-from deprecated import deprecated
 
 from kraken.common.pyenv import VirtualEnvInfo, get_current_venv
 from kraken.core import Project, Task, TaskRelationship, TaskStatus
@@ -38,10 +37,6 @@ class EnvironmentAwareDispatchTask(Task):
 
         yield from super().get_relationships()
 
-    @deprecated(reason="Implement get_execute_command_v2() instead")
-    def get_execute_command(self) -> list[str] | TaskStatus:
-        raise NotImplementedError()
-
     def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         raise NotImplementedError()
 
@@ -62,10 +57,7 @@ class EnvironmentAwareDispatchTask(Task):
 
     def execute(self) -> TaskStatus:
         env = os.environ.copy()
-        try:
-            command = self.get_execute_command_v2(env)
-        except NotImplementedError:
-            command = self.get_execute_command()
+        command = self.get_execute_command_v2(env)
         if isinstance(command, TaskStatus):
             return command
         if self.settings.build_system and self.settings.build_system.supports_managed_environments():

--- a/kraken-build/src/kraken/std/python/tasks/black_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/black_task.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Sequence
+from collections.abc import MutableMapping, Sequence
 from pathlib import Path
 
 from kraken.common import Supplier
 from kraken.core import Project, Property
+from kraken.core.system.task import TaskStatus
 from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .base_task import EnvironmentAwareDispatchTask
@@ -24,7 +25,7 @@ class BlackTask(EnvironmentAwareDispatchTask):
 
     # EnvironmentAwareDispatchTask
 
-    def get_execute_command(self) -> list[str]:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         command = [self.black_bin.get(), str(self.settings.source_directory)]
         command += self.settings.get_tests_directory_as_args()
         command += [str(directory) for directory in self.settings.lint_enforced_directories]

--- a/kraken-build/src/kraken/std/python/tasks/flake8_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/flake8_task.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import MutableMapping, Sequence
 from pathlib import Path
 
 from kraken.common import Supplier
 from kraken.core import Project, Property
+from kraken.core.system.task import TaskStatus
 from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .base_task import EnvironmentAwareDispatchTask
@@ -24,7 +25,7 @@ class Flake8Task(EnvironmentAwareDispatchTask):
 
     # EnvironmentAwareDispatchTask
 
-    def get_execute_command(self) -> list[str]:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         command = [
             self.flake8_bin.get(),
             str(self.settings.source_directory),

--- a/kraken-build/src/kraken/std/python/tasks/isort_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/isort_task.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Sequence
+from collections.abc import MutableMapping, Sequence
 from pathlib import Path
 
 from kraken.common import Supplier
 from kraken.core import Project, Property
+from kraken.core.system.task import TaskStatus
 from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .base_task import EnvironmentAwareDispatchTask
@@ -21,7 +22,7 @@ class IsortTask(EnvironmentAwareDispatchTask):
 
     # EnvironmentAwareDispatchTask
 
-    def get_execute_command(self) -> list[str]:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         command = [
             self.isort_bin.get(),
             str(self.settings.source_directory),

--- a/kraken-build/src/kraken/std/python/tasks/pycln_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pycln_task.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import dataclasses
 from pathlib import Path
+from typing import MutableMapping
 
 from kraken.common.supplier import Supplier
 from kraken.core import Project, Property
+from kraken.core.system.task import TaskStatus
 from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .base_task import EnvironmentAwareDispatchTask
@@ -23,7 +25,7 @@ class PyclnTask(EnvironmentAwareDispatchTask):
 
     # EnvironmentAwareDispatchTask
 
-    def get_execute_command(self) -> list[str]:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         command = [self.pycln_bin.get(), str(self.settings.source_directory)]
         command += self.settings.get_tests_directory_as_args()
         command += [str(directory) for directory in self.settings.lint_enforced_directories]

--- a/kraken-build/src/kraken/std/python/tasks/pylint_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pylint_task.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
+from typing import MutableMapping
 
 from kraken.common import Supplier
 from kraken.core import Project, Property
+from kraken.core.system.task import TaskStatus
 from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .base_task import EnvironmentAwareDispatchTask
@@ -20,7 +22,7 @@ class PylintTask(EnvironmentAwareDispatchTask):
 
     # EnvironmentAwareDispatchTask
 
-    def get_execute_command(self) -> list[str]:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         command = [
             self.pylint_bin.get(),
             str(self.settings.source_directory),

--- a/kraken-build/src/kraken/std/python/tasks/pytest_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pytest_task.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 import os
 import shlex
-from collections.abc import Sequence
+from collections.abc import MutableMapping, Sequence
 from pathlib import Path
 
 from kraken.common import flatten
@@ -43,7 +43,7 @@ class PytestTask(EnvironmentAwareDispatchTask):
     def is_skippable(self) -> bool:
         return self.allow_no_tests.get() and self.tests_dir.is_empty() and not self.settings.get_tests_directory()
 
-    def get_execute_command(self) -> list[str] | TaskStatus:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         tests_dir = self.tests_dir.get_or(None)
         tests_dir = tests_dir or self.settings.get_tests_directory()
         if not tests_dir:

--- a/kraken-build/src/kraken/std/python/tasks/pyupgrade_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pyupgrade_task.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Collection, Iterable, Sequence
+from collections.abc import Collection, Iterable, MutableMapping, Sequence
 from difflib import unified_diff
 from pathlib import Path
 from sys import stdout
@@ -26,7 +26,7 @@ class PyUpgradeTask(EnvironmentAwareDispatchTask):
 
     # EnvironmentAwareDispatchTask
 
-    def get_execute_command(self) -> list[str]:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         return self.run_pyupgrade(self.additional_files.get(), ("--exit-zero-even-if-changed",))
 
     def run_pyupgrade(self, files: Iterable[Path], extra: Iterable[str]) -> list[str]:
@@ -77,7 +77,7 @@ class PyUpgradeCheckTask(PyUpgradeTask):
                     )
             return result
 
-    def get_execute_command(self) -> list[str]:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         return self.run_pyupgrade(self._files, ())
 
 

--- a/kraken-build/src/kraken/std/python/tasks/ruff_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/ruff_task.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
 from kraken.common import Supplier
 from kraken.core import Project, Property
+from kraken.core.system.task import TaskStatus
 from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .base_task import EnvironmentAwareDispatchTask
@@ -22,7 +23,7 @@ class RuffTask(EnvironmentAwareDispatchTask):
     config_file: Property[Path]
     additional_args: Property[Sequence[str]] = Property.default_factory(list)
 
-    def get_execute_command(self) -> list[str]:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         command = [
             self.ruff_bin.get(),
             *self.ruff_task.get(),

--- a/kraken-build/src/kraken/std/util/copyright_task.py
+++ b/kraken-build/src/kraken/std/util/copyright_task.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Sequence
+from collections.abc import MutableMapping, Sequence
 from pathlib import Path
 
 from kraken.core import Project, Property
+from kraken.core.system.task import TaskStatus
 from kraken.std.python.tasks.base_task import EnvironmentAwareDispatchTask
 
 
@@ -19,7 +20,7 @@ class CopyrightTask(EnvironmentAwareDispatchTask):
     custom_license: Property[str]
     custom_license_file: Property[Path]
 
-    def get_execute_command(self) -> list[str]:
+    def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         command = ["pyaddlicense"]
 
         if self.holder.get() != "":

--- a/kraken-build/tests/kraken_std/util/test_copyright.py
+++ b/kraken-build/tests/kraken_std/util/test_copyright.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import cast
 
 from kraken.core import Project
 from kraken.std.util.copyright_task import check_and_format_copyright
@@ -9,11 +10,13 @@ _TEST_HOLDER = "Test Company"
 def test__copyright__execute_contains_check(kraken_project: Project) -> None:
     tasks = check_and_format_copyright(_TEST_HOLDER, project=kraken_project)
 
-    check_execute_list = tasks.check.get_execute_command()
+    check_execute_list = tasks.check.get_execute_command_v2({})
+    assert isinstance(check_execute_list, list)
     assert "-c" in check_execute_list
     assert len(check_execute_list) == 4
 
-    format_execute_list = tasks.format.get_execute_command()
+    format_execute_list = tasks.format.get_execute_command_v2({})
+    assert isinstance(format_execute_list, list)
     assert "-c" not in format_execute_list
     assert len(format_execute_list) == 3
 
@@ -21,12 +24,14 @@ def test__copyright__execute_contains_check(kraken_project: Project) -> None:
 def test__copyright__execute_contains_holder(kraken_project: Project) -> None:
     tasks = check_and_format_copyright(_TEST_HOLDER, project=kraken_project)
 
-    check_execute_list = tasks.check.get_execute_command()
+    check_execute_list = tasks.check.get_execute_command_v2({})
+    assert isinstance(check_execute_list, list)
     assert "-o" in check_execute_list
     assert f"{_TEST_HOLDER}" in check_execute_list
     assert len(check_execute_list) == 4
 
-    format_execute_list = tasks.format.get_execute_command()
+    format_execute_list = tasks.format.get_execute_command_v2({})
+    assert isinstance(format_execute_list, list)
     assert "-o" in format_execute_list
     assert f"{_TEST_HOLDER}" in format_execute_list
     assert len(format_execute_list) == 3
@@ -39,13 +44,15 @@ def test__copyright__execute_contains_ignore_when_given(kraken_project: Project)
 
     tasks = check_and_format_copyright(_TEST_HOLDER, project=kraken_project, ignore=test_ignore)
 
-    check_execute_list = tasks.check.get_execute_command()
+    check_execute_list = tasks.check.get_execute_command_v2({})
+    assert isinstance(check_execute_list, list)
     assert "-i" in check_execute_list
     assert test_str_1 in check_execute_list
     assert test_str_2 in check_execute_list
     assert len(check_execute_list) == 8
 
-    format_execute_list = tasks.format.get_execute_command()
+    format_execute_list = tasks.format.get_execute_command_v2({})
+    assert isinstance(format_execute_list, list)
     assert "-i" in format_execute_list
     assert test_str_1 in format_execute_list
     assert test_str_2 in format_execute_list
@@ -57,12 +64,14 @@ def test__copyright__execute_contains_license_when_given(kraken_project: Project
 
     tasks = check_and_format_copyright(_TEST_HOLDER, project=kraken_project, custom_license=license_str)
 
-    check_execute_list = tasks.check.get_execute_command()
+    check_execute_list = tasks.check.get_execute_command_v2({})
+    assert isinstance(check_execute_list, list)
     assert "-l" in check_execute_list
     assert f"{license_str}" in check_execute_list
     assert len(check_execute_list) == 6
 
-    format_execute_list = tasks.format.get_execute_command()
+    format_execute_list = tasks.format.get_execute_command_v2({})
+    assert isinstance(format_execute_list, list)
     assert "-l" in check_execute_list
     assert f"{license_str}" in format_execute_list
     assert len(format_execute_list) == 5
@@ -73,12 +82,14 @@ def test__copyright__execute_contains_license_filepath_when_given(kraken_project
 
     tasks = check_and_format_copyright(_TEST_HOLDER, project=kraken_project, custom_license_file=test_license_file)
 
-    assert str(test_license_file) in tasks.format.get_execute_command()
+    assert str(test_license_file) in cast(list[str], tasks.format.get_execute_command_v2({}))
 
-    check_execute_list = tasks.check.get_execute_command()
+    check_execute_list = tasks.check.get_execute_command_v2({})
+    assert isinstance(check_execute_list, list)
     assert str(test_license_file) in check_execute_list
     assert len(check_execute_list) == 6
 
-    format_execute_list = tasks.format.get_execute_command()
+    format_execute_list = tasks.format.get_execute_command_v2({})
+    assert isinstance(format_execute_list, list)
     assert str(test_license_file) in format_execute_list
     assert len(format_execute_list) == 5


### PR DESCRIPTION
Remove most deprecated APIs.

* `Project.path`
* `Project.resolve_tasks()`
* `Property.config()`
* `Task.path`
* `Task.add_relationship()`
* `EnvironmentAwareDispatchTask.get_execute_command()`

We can not yet remove

* `Project.do()` as it fulfils a purpose for at least `docker_build_image()`
* `Task.outputs` and `Task.get_outputs()` because the `kraken.std.dist` module depends on the mechanism

The interface for `Context.resolve_tasks()` was adjusted to accept an `Iterable` over a `Sequence`.