### PR TITLE
Run CI on Python 3.13

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "5edb6a12-7001-4c4a-8fca-cf95cfd88b7b"
+type = "improvement"
+description = "Run CI with Python 3.13"
+author = "thomas.pellissier-tanon@helsing.ai"

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.x"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         tasks: ["check lint", "test"]
     steps:
     - uses: actions/checkout@v4
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.x"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - uses: NiklasRosenstein/slap@gha/install/v1


### PR DESCRIPTION
Drops 3.x that is currently an alias for 3.12