### PR TITLE
Remove `uv` as a direct dependency in kraken-build

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -15,3 +15,9 @@ id = "4d8a687f-14ae-4644-904a-80b1aef3421b"
 type = "improvement"
 description = "Support management of package indexes for uv"
 author = "antoine.broyelle@helsing.ai"
+
+[[entries]]
+id = "06add927-62e1-4503-b82f-88000bd29da1"
+type = "improvement"
+description = "Remove `uv` as a direct dependency"
+author = "antoine.broyelle@helsing.ai"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -19,5 +19,5 @@ author = "antoine.broyelle@helsing.ai"
 [[entries]]
 id = "06add927-62e1-4503-b82f-88000bd29da1"
 type = "improvement"
-description = "Remove `uv` as a direct dependency"
+description = "Remove `uv` as a direct dependency in kraken-build"
 author = "antoine.broyelle@helsing.ai"

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -68,7 +68,7 @@ jobs:
     - uses: NiklasRosenstein/slap@gha/install/v1
     - uses: actions/setup-python@v5
       with: { python-version: "${{ matrix.python-version }}" }
-    - run: pip install pipx && pipx install poetry && pipx install pdm && pipx install kraken-wrapper==0.34.1 && krakenw config --installer=UV
+    - run: pip install pipx && pipx install poetry && pipx install pdm && pipx install uv && pipx install kraken-wrapper==0.34.1 && krakenw config --installer=UV
     - run: rustup update
     - run: slap config --venv-type=uv
 

--- a/docs/docs/lang/python.md
+++ b/docs/docs/lang/python.md
@@ -15,11 +15,14 @@ __Supported tools__
 * Pylint
 * Pytest
 * Pyupgrade
+* ruff
 
 __Supported build systems (for installing/building)__
 
 * Poetry
+* PDM
 * Slap
+* uv
 
 ## Build systems
 
@@ -29,6 +32,9 @@ create a virtual environment and install the project into it).
 
 Build systems implemented for Kraken will take care of the installation, ensuring that the Python package indexes
 registered in the build script are made available to the installation process.
+
+Kraken assumes that these package managers or build systems are installed locally by the user and accesible in the `$PATH`.
+If you use a custom installation, make sure these tools are available in there.
 
 ### Poetry
 

--- a/kraken-build/src/kraken/std/python/buildsystem/maturin.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/maturin.py
@@ -272,16 +272,11 @@ class MaturinUvPythonBuildSystem(UvPythonBuildSystem):
 
     name = "Maturin UV"
 
-    def __init__(self, project_directory: Path, uv_bin: Path | None = None) -> None:
-        super().__init__(project_directory, uv_bin)
+    def __init__(self, project_directory: Path) -> None:
+        super().__init__(project_directory)
         # We use the build requirement to do custom Maturin builds
         self._builder = _MaturinBuilder(
-            [
-                self.uv_bin,
-                "tool",
-                "run",
-                *chain.from_iterable(("--with", r) for r in self._get_build_requirements()),
-            ],
+            ["uv", "tool", "run", *chain.from_iterable(("--with", r) for r in self._get_build_requirements())],
             self.get_pyproject_reader,
             self.project_directory,
         )

--- a/kraken-build/src/kraken/std/python/buildsystem/poetry.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/poetry.py
@@ -211,8 +211,8 @@ class PoetryManagedEnvironment(ManagedEnvironment):
             if exc.returncode != 1:
                 raise
             return None
-        else:
-            return Path(response)
+
+        return Path(response)
 
     def _get_all_poetry_known_environment_paths(self) -> list[Path]:
         """Uses `poetry env list --full-path` to get the path to all relevant virtual environments that are known
@@ -225,8 +225,8 @@ class PoetryManagedEnvironment(ManagedEnvironment):
             if exc.returncode != 1:
                 raise
             return []
-        else:
-            return [Path(line.replace(" (Activated)", "").strip()) for line in response if line]
+
+        return [Path(line.replace(" (Activated)", "").strip()) for line in response if line]
 
     def _get_poetry_environment_path(self) -> Path | None:
         # Run the two Poetry commands we need to run in parallel to improve load times.
@@ -249,8 +249,7 @@ class PoetryManagedEnvironment(ManagedEnvironment):
 
     def exists(self) -> bool:
         try:
-            self.get_path()
-            return True
+            return self.get_path().is_dir()
         except RuntimeError:
             return False
 
@@ -258,7 +257,7 @@ class PoetryManagedEnvironment(ManagedEnvironment):
         if self._env_path is NotSet.Value:
             self._env_path = self._get_poetry_environment_path()
         if self._env_path is None:
-            raise RuntimeError("managed environment does not exist")
+            raise RuntimeError("Managed environment does not exist")
         return self._env_path
 
     def install(self, settings: PythonSettings) -> None:

--- a/kraken-build/tests/kraken_std/integration/python/test_python.py
+++ b/kraken-build/tests/kraken_std/integration/python/test_python.py
@@ -105,13 +105,14 @@ def test__python_project_install_lint_and_publish(
     shutil.copytree(example_dir(project_dir), tempdir / project_dir)
     shutil.copytree(example_dir(consumer_dir), tempdir / consumer_dir)
 
-    # TODO (@NiklasRosenstein): Make sure Poetry installs the environment locally so it gets cleaned up
-    #       with the temporary directory.
-
     logger.info("Loading and executing Kraken project (%s)", tempdir / project_dir)
+    # TODO: mock the `os.environ` dict instead of mutating the global one
     os.environ["LOCAL_PACKAGE_INDEX"] = pypiserver
     os.environ["LOCAL_USER"] = USER_NAME
     os.environ["LOCAL_PASSWORD"] = USER_PASS
+    # Make sure Poetry installs the environment locally so it gets cleaned up
+    os.environ["POETRY_VIRTUALENVS_IN_PROJECT"] = "1"
+
     kraken_ctx.load_project(directory=tempdir / project_dir)
     kraken_ctx.execute([":lint", ":publish"])
 

--- a/kraken-build/tests/kraken_std/integration/python/test_python.py
+++ b/kraken-build/tests/kraken_std/integration/python/test_python.py
@@ -107,6 +107,7 @@ def test__python_project_install_lint_and_publish(
 
     logger.info("Loading and executing Kraken project (%s)", tempdir / project_dir)
     # TODO: mock the `os.environ` dict instead of mutating the global one
+    os.environ["UV_DEFAULT_INDEX"] = pypiserver
     os.environ["LOCAL_PACKAGE_INDEX"] = pypiserver
     os.environ["LOCAL_USER"] = USER_NAME
     os.environ["LOCAL_PASSWORD"] = USER_PASS


### PR DESCRIPTION
This mimics how other package managers are operated, that is by assuming they are installed by the user and available via the `PATH` environment variable. This will also reduce potential mismatches between the different installed versions.

Stacked on #297 