### PR TITLE
Remove --log-cli-level INFO when calling pytest

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -33,3 +33,9 @@ id = "00ded573-ed92-4aab-b480-e21589718bbd"
 type = "fix"
 description = "Remove used of deprecated flag to be removed in pip 25.1"
 author = "scott@stevenson.io"
+
+[[entries]]
+id = "c34f7131-4e5d-482f-b654-bd08976c59fc"
+type = "fix"
+description = "Remove --log-cli-level INFO when calling pytest. This option can be added back by the users via their configuration files."
+author = "antoine.broyelle@helsing.ai"

--- a/kraken-build/src/kraken/std/python/tasks/pytest_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pytest_task.py
@@ -69,7 +69,6 @@ class PytestTask(EnvironmentAwareDispatchTask):
             *[str(self.project.directory / path) for path in self.include_dirs.get()],
         ]
         command += flatten(["--ignore", str(self.project.directory / path)] for path in self.ignore_dirs.get())
-        command += ["--log-cli-level", "INFO"]
         if self.coverage.is_filled():
             coverage_file = f"coverage{self.coverage.get().get_suffix()}"
             command += [


### PR DESCRIPTION
Setting the log level to INFO displays all the test names. If the test suite is large the logs long can be hard to digest. `pytest-xdist` make the problem even worse by printing each test name twice, on start and on completion. Moreover, this argument can conflict with options specified in the `pyproject.toml`, preventing users from adjusting the information displayed by pytest. By removing this option, one would be able to track progress with a progress bar for example while still displaying the test name in the summary table if needed.

Solves https://github.com/kraken-build/kraken/issues/300