### PR TITLE
Use `uv tool` instead of `pex` to run Python tools

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -21,3 +21,9 @@ id = "1898e101-4ef2-44c0-9832-c1b2ca0c39b6"
 type = "fix"
 description = "Address tool.poetry.dev-dependencies deprecation warnings"
 author = "scott@stevenson.io"
+
+[[entries]]
+id = "faea65a7-ef87-457c-8c7b-523bab205e00"
+type = "improvement"
+description = "Use `uv tool` instead of `pex` to run Python tools"
+author = "scott@stevenson.io"

--- a/kraken-build/pyproject.toml
+++ b/kraken-build/pyproject.toml
@@ -60,6 +60,7 @@ pytest = ">=6.0.0"
 mitmproxy = "^11.0.0"
 types-networkx = "^3.2.1.20240703"
 requests-mock = "^1.12.1"
+types-requests = "^2.32.0.20241016"
 
 # Slap configuration
 # ------------------

--- a/kraken-build/src/kraken/std/cargo/__init__.py
+++ b/kraken-build/src/kraken/std/cargo/__init__.py
@@ -9,7 +9,6 @@ from typing import Literal
 
 from kraken.common import Supplier
 from kraken.core import Project, Task
-from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .config import CargoConfig, CargoProject, CargoRegistry
 from .tasks.cargo_auth_proxy_task import CargoAuthProxyTask
@@ -178,13 +177,11 @@ def cargo_auth_proxy(*, project: Project | None = None) -> CargoAuthProxyTask:
     project = project or Project.current()
     cargo = CargoProject.get_or_create(project)
 
-    mitmweb_bin = pex_build(
-        "mitmweb", requirements=["mitmproxy>=10.0.0,<11.0.0"], console_script="mitmweb"
-    ).output_file.map(lambda p: str(p.absolute()))
+    mitmweb_cmd = Supplier.of(["uv", "tool", "run", "--from", "mitmproxy>=10.0.0,<11.0.0", "mitmweb"])
 
     task = project.task("cargoAuthProxy", CargoAuthProxyTask, group=CARGO_BUILD_SUPPORT_GROUP_NAME)
     task.registries = Supplier.of_callable(lambda: list(cargo.registries.values()))
-    task.mitmweb_bin = mitmweb_bin
+    task.mitmweb_cmd = mitmweb_cmd
 
     # The auth proxy is required for both building and publishing cargo packages with private cargo project dependencies
     project.group(CARGO_PUBLISH_SUPPORT_GROUP_NAME).add(task)

--- a/kraken-build/src/kraken/std/cargo/tasks/cargo_auth_proxy_task.py
+++ b/kraken-build/src/kraken/std/cargo/tasks/cargo_auth_proxy_task.py
@@ -38,7 +38,7 @@ class CargoAuthProxyTask(BackgroundTask):
     proxy_cert_file: Property[Path] = Property.output()
 
     #: Path to the mitmweb binary.
-    mitmweb_bin: Property[str] = Property.default("mitmweb")
+    mitmweb_cmd: Property[Sequence[str]] = Property.default(["mitmweb"])
 
     #: Additional args for the mitmproxy.
     #: We pass `--no-http2` by default as that breaks Cargo HTTP/2 multiplexing. See
@@ -99,7 +99,7 @@ class CargoAuthProxyTask(BackgroundTask):
             auth[host] = registry.read_credentials
 
         proxy_url, cert_file = start_mitmweb_proxy(
-            auth=auth, mitmweb_bin=self.mitmweb_bin.get(), additional_args=self.mitmproxy_additional_args.get()
+            auth=auth, mitmweb_cmd=self.mitmweb_cmd.get(), additional_args=self.mitmproxy_additional_args.get()
         )
         self.proxy_url.set(proxy_url)
         self.proxy_cert_file.set(cert_file)

--- a/kraken-build/src/kraken/std/mitm/__init__.py
+++ b/kraken-build/src/kraken/std/mitm/__init__.py
@@ -26,7 +26,7 @@ inject_auth_addon_file = Path(__file__).parent / "mitm_addon.py"
 
 def start_mitmweb_proxy(
     auth: Mapping[str, tuple[str, str]],
-    mitmweb_bin: str = "mitmweb",
+    mitmweb_cmd: Sequence[str] = ("mitmweb",),
     additional_args: Sequence[str] = (),
 ) -> tuple[str, Path]:
     """
@@ -41,7 +41,7 @@ def start_mitmweb_proxy(
     controller = DaemonController("kraken.mitmweb", daemon_state_file)
     started = controller.run(
         command=[
-            mitmweb_bin,
+            *mitmweb_cmd,
             "--no-web-open-browser",
             "--web-port",
             str(mitmweb_ui_port),

--- a/kraken-build/src/kraken/std/python/tasks/flake8_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/flake8_task.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import MutableMapping, Sequence
+from itertools import chain
 from pathlib import Path
 
 from kraken.common import Supplier
 from kraken.core import Project, Property
 from kraken.core.system.task import TaskStatus
-from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .base_task import EnvironmentAwareDispatchTask
 
@@ -19,7 +19,7 @@ class Flake8Task(EnvironmentAwareDispatchTask):
     description = "Lint Python source files with Flake8."
     python_dependencies = ["flake8"]
 
-    flake8_bin: Property[str] = Property.default("flake8")
+    flake8_cmd: Property[Sequence[str]] = Property.default(["flake8"])
     config_file: Property[Path]
     additional_args: Property[list[str]] = Property.default_factory(list)
 
@@ -27,7 +27,7 @@ class Flake8Task(EnvironmentAwareDispatchTask):
 
     def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
         command = [
-            self.flake8_bin.get(),
+            *self.flake8_cmd.get(),
             str(self.settings.source_directory),
         ] + self.settings.get_tests_directory_as_args()
         command += [str(directory) for directory in self.settings.lint_enforced_directories]
@@ -47,24 +47,30 @@ def flake8(
 ) -> Flake8Task:
     """Creates a task for linting your Python project with Flake8.
 
-    :param version_spec: If specified, the Flake8 tool will be installed as a PEX and does not need to be installed
+    :param version_spec: If specified, the Flake8 tool will be run via `uv tool run` and does not need to be installed
         into the Python project's virtual env.
+    :param additional_requirements: Additional requirements to pass to `uv tool run`.
     """
 
     project = project or Project.current()
 
     if version_spec is not None:
-        flake8_bin = pex_build(
-            "flake8",
-            requirements=[f"flake8{version_spec}", *additional_requirements],
-            console_script="flake8",
-            project=project,
-        ).output_file.map(str)
+        flake8_cmd = Supplier.of(
+            [
+                "uv",
+                "tool",
+                "run",
+                "--from",
+                f"flake8{version_spec}",
+                *chain.from_iterable(("--with", r) for r in additional_requirements),
+                "flake8",
+            ]
+        )
     else:
-        flake8_bin = Supplier.of("flake8")
+        flake8_cmd = Supplier.of(["flake8"])
 
     task = project.task(name, Flake8Task, group="lint")
-    task.flake8_bin = flake8_bin
+    task.flake8_cmd = flake8_cmd
     if config_file is not None:
         task.config_file = config_file
     return task

--- a/kraken-build/src/kraken/std/python/tasks/mypy_stubtest_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/mypy_stubtest_task.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, Sequence
 from pathlib import Path
 
 from kraken.core import Project, Property
@@ -12,7 +12,7 @@ class MypyStubtestTask(EnvironmentAwareDispatchTask):
     description = "Static validation for Python type stubs using Mypy."
     python_dependencies = ["mypy"]
 
-    mypy_pex_bin: Property[Path | None] = Property.default(None)
+    mypy_cmd: Property[Sequence[str] | None] = Property.default(None)
     package: Property[str]
     ignore_missing_stubs: Property[bool] = Property.default(False)
     ignore_positional_only: Property[bool] = Property.default(False)
@@ -22,10 +22,8 @@ class MypyStubtestTask(EnvironmentAwareDispatchTask):
     # EnvironmentAwareDispatchTask
 
     def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str]:
-        if mypy_pex_bin := self.mypy_pex_bin.get():
-            command = [str(mypy_pex_bin)]
-            # See https://pex.readthedocs.io/en/latest/api/vars.html
-            env["PEX_MODULE"] = "mypy.stubtest"
+        if mypy_cmd := self.mypy_cmd.get():
+            command = [*mypy_cmd]
         else:
             command = ["python", "-m", "mypy.stubtest"]
         command += [self.package.get()]
@@ -49,16 +47,16 @@ def mypy_stubtest(
     ignore_positional_only: bool = False,
     allowlist: Path | None = None,
     mypy_config_file: Path | None = None,
-    mypy_pex_bin: Path | Property[Path] | None = None,
+    mypy_cmd: Sequence[str] | Property[Sequence[str]] | None = None,
 ) -> MypyStubtestTask:
     """
-    :param version_spec: If specified, the isort tool will be installed as a PEX and does not need to be installed
+    :param version_spec: If specified, the mypy tool will be run via this command and does not need to be installed
         into the Python project's virtual env.
     """
 
     project = project or Project.current()
     task = project.task(name, MypyStubtestTask, group="lint")
-    task.mypy_pex_bin = mypy_pex_bin
+    task.mypy_cmd = mypy_cmd
     task.package = package
     task.ignore_missing_stubs = ignore_missing_stubs
     task.ignore_positional_only = ignore_positional_only

--- a/kraken-build/src/kraken/std/python/tasks/pycln_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pycln_task.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import MutableMapping, Sequence
 from pathlib import Path
-from typing import MutableMapping
 
 from kraken.common.supplier import Supplier
 from kraken.core import Project, Property
 from kraken.core.system.task import TaskStatus
-from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .base_task import EnvironmentAwareDispatchTask
 
@@ -17,7 +16,7 @@ class PyclnTask(EnvironmentAwareDispatchTask):
 
     python_dependencies = ["pycln"]
 
-    pycln_bin: Property[str] = Property.default("pycln")
+    pycln_cmd: Property[Sequence[str]] = Property.default(["pycln"])
     check_only: Property[bool] = Property.default(False)
     config_file: Property[Path]
     additional_args: Property[list[str]] = Property.default_factory(list)
@@ -26,7 +25,7 @@ class PyclnTask(EnvironmentAwareDispatchTask):
     # EnvironmentAwareDispatchTask
 
     def get_execute_command_v2(self, env: MutableMapping[str, str]) -> list[str] | TaskStatus:
-        command = [self.pycln_bin.get(), str(self.settings.source_directory)]
+        command = [*self.pycln_cmd.get(), str(self.settings.source_directory)]
         command += self.settings.get_tests_directory_as_args()
         command += [str(directory) for directory in self.settings.lint_enforced_directories]
         command += [str(p) for p in self.additional_files.get()]
@@ -54,21 +53,19 @@ def pycln(*, name: str = "python.pycln", project: Project | None = None, version
     """Creates two pycln tasks, one to check and another to format. The check task will be grouped under `"lint"`
     whereas the format task will be grouped under `"fmt"`.
 
-    :param version_spec: If specified, the pycln tool will be installed as a PEX and does not need to be installed
+    :param version_spec: If specified, the pycln tool will be run via `uv tool run` and does not need to be installed
         into the Python project's virtual env.
     """
 
     project = project or Project.current()
     if version_spec is not None:
-        pycln_bin = pex_build(
-            "pycln", requirements=[f"pycln{version_spec}"], console_script="pycln", project=project
-        ).output_file.map(str)
+        pycln_cmd = Supplier.of(["uv", "tool", "run", "--from", f"pycln{version_spec}", "pycln"])
     else:
-        pycln_bin = Supplier.of("pycln")
+        pycln_cmd = Supplier.of(["pycln"])
 
     check_task = project.task(f"{name}.check", PyclnTask, group="lint")
-    check_task.pycln_bin = pycln_bin
+    check_task.pycln_cmd = pycln_cmd
     check_task.check_only = True
     format_task = project.task(name, PyclnTask, group="fmt")
-    format_task.pycln_bin = pycln_bin
+    format_task.pycln_cmd = pycln_cmd
     return PyclnTasks(check_task, format_task)

--- a/kraken-build/src/kraken/std/python/tasks/pyupgrade_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pyupgrade_task.py
@@ -9,7 +9,6 @@ from tempfile import TemporaryDirectory
 
 from kraken.common.supplier import Supplier
 from kraken.core import Project, Property, TaskStatus
-from kraken.std.python.tasks.pex_build_task import pex_build
 
 from .. import python_settings
 from .base_task import EnvironmentAwareDispatchTask
@@ -19,7 +18,7 @@ class PyUpgradeTask(EnvironmentAwareDispatchTask):
     description = "Upgrades to newer Python syntax sugars with pyupgrade."
     python_dependencies = ["pyupgrade"]
 
-    pyupgrade_bin: Property[str] = Property.default("pyupgrade")
+    pyupgrade_cmd: Property[Sequence[str]] = Property.default(["pyupgrade"])
     keep_runtime_typing: Property[bool] = Property.default(False)
     additional_files: Property[Sequence[Path]] = Property.default_factory(list)
     python_version: Property[str]
@@ -30,7 +29,7 @@ class PyUpgradeTask(EnvironmentAwareDispatchTask):
         return self.run_pyupgrade(self.additional_files.get(), ("--exit-zero-even-if-changed",))
 
     def run_pyupgrade(self, files: Iterable[Path], extra: Iterable[str]) -> list[str]:
-        command = [self.pyupgrade_bin.get(), f"--py{self.python_version.get_or('3').replace('.', '')}-plus", *extra]
+        command = [*self.pyupgrade_cmd.get(), f"--py{self.python_version.get_or('3').replace('.', '')}-plus", *extra]
         if self.keep_runtime_typing.get():
             command.append("--keep-runtime-typing")
         command.extend(str(f) for f in files)
@@ -99,18 +98,16 @@ def pyupgrade(
     version_spec: str | None = None,
 ) -> PyUpgradeTasks:
     """
-    :param version_spec: If specified, the pyupgrade tool will be installed as a PEX and does not need to be installed
+    :param version_spec: If specified, the pyupgrade tool will be run via `uv tool run` and does not need to be installed
         into the Python project's virtual env.
     """
 
     project = project or Project.current()
 
     if version_spec is not None:
-        pyupgrade_bin = pex_build(
-            "pyupgrade", requirements=[f"pyupgrade{version_spec}"], console_script="pyupgrade", project=project
-        ).output_file.map(str)
+        pyupgrade_cmd = Supplier.of(["uv", "tool", "run", "--from", f"pyupgrade{version_spec}", "pyupgrade"])
     else:
-        pyupgrade_bin = Supplier.of("pyupgrade")
+        pyupgrade_cmd = Supplier.of(["pyupgrade"])
 
     settings = python_settings(project)
 
@@ -128,13 +125,13 @@ def pyupgrade(
     ]
 
     check_task = project.task(f"{name}.check", PyUpgradeCheckTask, group="lint")
-    check_task.pyupgrade_bin = pyupgrade_bin
+    check_task.pyupgrade_cmd = pyupgrade_cmd
     check_task.additional_files = filtered_files
     check_task.keep_runtime_typing = keep_runtime_typing
     check_task.python_version = python_version
 
     format_task = project.task(name, PyUpgradeTask, group="fmt")
-    format_task.pyupgrade_bin = pyupgrade_bin
+    format_task.pyupgrade_cmd = pyupgrade_cmd
     format_task.additional_files = filtered_files
     format_task.keep_runtime_typing = keep_runtime_typing
     format_task.python_version = python_version

--- a/kraken-build/tests/kraken_std/integration/python/test_python.py
+++ b/kraken-build/tests/kraken_std/integration/python/test_python.py
@@ -291,6 +291,8 @@ def test__python_project_can_lint_lint_enforced_directories(
     python.settings.python_settings(
         project=kraken_project, lint_enforced_directories=[tempdir / "examples", tempdir / "bin"]
     )
+    python.install(project=kraken_project)
+
     for linter, version in {
         "black": "23.12.1",
         "flake8": "6.1.0",


### PR DESCRIPTION
This MR adopts [uv's support for invoking Python tools](https://docs.astral.sh/uv/guides/tools/). This provides fast resolution and caching, and allows us to replace the previous approach of generating pex files for each formatter and linter. The pex build task will be removed in a follow up PR.