### PR TITLE
Remove use of deprecated flag to be removed in pip 25.1

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -27,3 +27,9 @@ id = "3faaa1ff-aafc-4fee-bbd6-dd91a258d483"
 type = "fix"
 description = "Fixes build of Maturin projects that use UV to properly build wheels using Maturin"
 author = "thomas.pellissier-tanon@helsing.ai"
+
+[[entries]]
+id = "00ded573-ed92-4aab-b480-e21589718bbd"
+type = "fix"
+description = "Remove used of deprecated flag to be removed in pip 25.1"
+author = "scott@stevenson.io"

--- a/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
@@ -121,7 +121,6 @@ class VenvBuildEnv(BuildEnv):
             "pip",
             "install",
             "--disable-pip-version-check",
-            "--no-python-version-warning",
             "--no-input",
         ]
         # Must enable transitive resolution because lock files are not currently cross platform (see kraken-wrapper#2).


### PR DESCRIPTION
The `--no-python-version-warning` flag was used by pip only to suppress "Python 2 is sunsetting support" messages, and is deprecated. It will be removed in pip 25.1:
https://github.com/pypa/pip/blob/f5ff4fa27dd991f209f2a9f9283a7c1561221b2c/src/pip/_internal/cli/base_command.py#L233-L238