### PR TITLE
Directly call `uv build` even when no `[build-system]` is specified in the `pyproject.toml`

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "62408706-cb66-49ed-95cf-d44382829ed6"
 type = "hygiene"
 description = "Remove unused dependencies"
 author = "thomas.pellissier-tanon@helsing.ai"
+
+[[entries]]
+id = "18cfdd07-b11d-4d22-906f-bc4080cda316"
+type = "improvement"
+description = "Directly call `uv build` even when no `[build-system]` is specified in the `pyproject.toml`"
+author = "antoine.broyelle@helsing.ai"


### PR DESCRIPTION
Extract from [the `uv` documentation on build systems](https://docs.astral.sh/uv/concepts/projects/config/#build-systems): 

> While uv will not build and install the current project without a build system definition, the presence of a [build-system] table is not required in other packages. For legacy reasons, if a build system is not defined, then setuptools.build_meta:__legacy__ is used to build the package. Packages you depend on may not explicitly declare their build system but are still installable. Similarly, if you add a dependency on a local package or install it with uv pip, uv will always attempt to build and install it.

As such, this PR is proposing to remove the reliance on `pyproject-build` in favor of `uv build`.