### PR TITLE
Avoid reading pyproject.toml when installing Kraken venv to avoid conflicts between indexes

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -57,3 +57,9 @@ id = "e3edc5a7-39ec-4e05-89c8-d06bf8cb0ee8"
 type = "feature"
 description = "Enabling `UvPyprojectHandler` to properly bump versions for path dependencies"
 author = "alexandre.ghelfi@helsing.ai"
+
+[[entries]]
+id = "19bd61b5-7cda-499e-9e8a-a4b913141392"
+type = "fix"
+description = "Avoid reading pyproject.toml when installing Kraken venv to avoid conflicts between indexes"
+author = "thomas.pellissier-tanon@helsing.ai"

--- a/kraken-wrapper/src/kraken/wrapper/_buildenv_uv.py
+++ b/kraken-wrapper/src/kraken/wrapper/_buildenv_uv.py
@@ -32,7 +32,7 @@ class UvBuildEnv(_VenvBuildEnv):
 
     def _get_install_command(self, venv_dir: Path, requirements: RequirementSpec, env: dict[str, str]) -> list[str]:
         env["VIRTUAL_ENV"] = str(venv_dir)
-        return [self._uv_bin, "pip", "install", *requirements.to_args(base_dir=self._project_root)]
+        return [self._uv_bin, "pip", "install", "--no-config", *requirements.to_args(base_dir=self._project_root)]
 
     def get_type(self) -> EnvironmentType:
         return EnvironmentType.UV


### PR DESCRIPTION
By default `uv pip` reads the local `pyproject.toml` and uses indexes declared there. Kraken has its own indexes configuration format and we want to avoid conflicts between them