### PR TITLE
Add `publish` job to publish from CI on tags

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "69495c76-ca33-4089-87df-ee64b280c939"
+type = "improvement"
+description = "publish from CI"
+author = "@NiklasRosenstein"

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -164,3 +164,25 @@ jobs:
       with: { python-version: "${{ matrix.python-version }}" }
     - run: slap config --venv-type=uv && slap install --link --no-venv-check ${{ matrix.only }}
     - run: cd examples/docker-manual && kraken run :dockerBuild :sub:helloWorld
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    environment: release
+    permissions:
+      id-token: write
+    if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: NiklasRosenstein/slap@gha/install/v1
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Build dist
+        run: slap publish --dry --build-directory dist/
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
This PR adds a CI job to publish the packages to PyPI via the GitHub trusted publisher authentication. I've set up the trusted publishers prior for `kraken-build` and `kraken-wrapper`:

![image](https://github.com/user-attachments/assets/84ea1ace-0130-427f-bb13-e23bcbc54558)

After this is merged, the regular workflow of using `slap release -tp <version>` to bump version numbers and commit, tag and push to `develop` will now also trigger the publishing automatically.
