### PR TITLE
[uv] Primary index is not treated as default

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -9,3 +9,9 @@ id = "18cfdd07-b11d-4d22-906f-bc4080cda316"
 type = "improvement"
 description = "Directly call `uv build` even when no `[build-system]` is specified in the `pyproject.toml`"
 author = "antoine.broyelle@helsing.ai"
+
+[[entries]]
+id = "f4662450-3fb1-401a-815c-260b9eff6dbe"
+type = "fix"
+description = "Primary index is not treated as default by uv"
+author = "antoine.broyelle@helsing.ai"

--- a/kraken-build/src/kraken/std/python/buildsystem/uv.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/uv.py
@@ -57,7 +57,7 @@ class UvIndex:
         return UvIndex(
             index.index_url,
             name=index.alias if index.alias != "" else None,
-            default=index.priority == index.Priority.default or index.priority == index.Priority.primary,
+            default=index.priority == index.Priority.default,
             explicit=index.priority == index.Priority.explicit,
             credentials=credentials,
         )


### PR DESCRIPTION
The index marked as `default` in uv will be treated as the last index (as a replacement of pypi). As such a primary index (the first one to look into) should not be treated as default.