### PR TITLE
pytest: don't scan `src/`

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "4f5b1b3d-422f-4466-be88-2ef688bcff11"
 type = "breaking change"
 description = "Remove pex build task"
 author = "scott@stevenson.io"
+
+[[entries]]
+id = "cac87925-0145-4281-a719-beac302c1d7e"
+type = "breaking change"
+description = "pytest: don't scan `src/`"
+author = "antoine.broyelle@helsing.ai"

--- a/kraken-build/src/kraken/std/python/tasks/pytest_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pytest_task.py
@@ -61,10 +61,20 @@ class PytestTask(EnvironmentAwareDispatchTask):
                 DeprecationWarning,
             )
 
+        if (
+            self.settings.source_directory not in tests_dir
+            and self.settings.source_directory not in self.include_dirs.get()
+            and list((self.project.directory / self.settings.source_directory).rglob("*_test.py"))
+        ):
+            warnings.warn(
+                f"Some test files are detected inside the source directory '{self.settings.source_directory }'. "
+                f"These tests will be skipped. Consider adding '{self.settings.source_directory }' to `tests_dir`.",
+                DeprecationWarning,
+            )
+
         command = [
             "pytest",
             "-vv",
-            str(self.project.directory / self.settings.source_directory),
             *[str(self.project.directory / path) for path in tests_dir],
             *[str(self.project.directory / path) for path in self.include_dirs.get()],
         ]

--- a/kraken-build/src/kraken/std/python/tasks/pytest_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/pytest_task.py
@@ -67,8 +67,8 @@ class PytestTask(EnvironmentAwareDispatchTask):
             and list((self.project.directory / self.settings.source_directory).rglob("*_test.py"))
         ):
             warnings.warn(
-                f"Some test files are detected inside the source directory '{self.settings.source_directory }'. "
-                f"These tests will be skipped. Consider adding '{self.settings.source_directory }' to `tests_dir`.",
+                f"Some test files are detected inside the source directory '{self.settings.source_directory}'. "
+                f"These tests will be skipped. Consider adding '{self.settings.source_directory}' to `tests_dir`.",
                 DeprecationWarning,
             )
 


### PR DESCRIPTION
Kraken defaults orient the users towards having source files under `src/` and tests under `tests/`. Pytest don't need to know where the source code is, it should be installed (as editable) in the virtual environment in which the tests are executed.

I stumbled upon this problem when working with an optional dependency. The tests were skipped as expected but `krakenw run :python.test.unit` was failing. The submodule built around the optional dependency was scanned by `pytest` and imports raised errors.