### PR TITLE
Cleaning build directory when building with uv

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -9,3 +9,9 @@ id = "cac87925-0145-4281-a719-beac302c1d7e"
 type = "breaking change"
 description = "pytest: don't scan `src/`"
 author = "antoine.broyelle@helsing.ai"
+
+[[entries]]
+id = "2c4f01f6-5d12-428f-8d36-f12a4f4dd327"
+type = "fix"
+description = "Clean build directory before building with uv"
+author = "alexandre.ghelfi@helsing.ai"

--- a/kraken-build/src/kraken/std/python/buildsystem/uv.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/uv.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess as sp
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -280,9 +281,12 @@ class UvPythonBuildSystem(PythonBuildSystem):
 
         [build]: https://pypi.org/project/build/
         """
-        _run_with_uv_indexes(
-            ["uv", "build", f"--out-dir={output_directory.absolute()}"], settings, self.project_directory
-        )
+        # Making sure the build directory is clean
+        dist_dir = output_directory.absolute()
+        if dist_dir.exists():
+            shutil.rmtree(dist_dir)
+
+        _run_with_uv_indexes(["uv", "build", f"--out-dir={dist_dir}"], settings, self.project_directory)
         return list(f for f in output_directory.iterdir() if f.is_file() and not f.name.startswith("."))
 
     def get_lockfile(self) -> Path | None:


### PR DESCRIPTION
Adopting the same logic used for Poetry. The build directory is cleaned before the build task.
This avoid having whl file from different version being store in the same directory.