### PR TITLE
Document that UV is now the default installer type

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "e64939c7-c061-46c3-a148-a81a2b0a4e97"
 type = "deprecation"
 description = "Deprecate Maturin + PDM project support"
 author = "thomas.pellissier-tanon@helsing.ai"
+
+[[entries]]
+id = "88bdf23d-4098-4933-95ed-ebcc5da5466d"
+type = "docs"
+description = "Document that UV is now the default installer type"
+author = "scott@stevenson.io"

--- a/docs/docs/krakenw.md
+++ b/docs/docs/krakenw.md
@@ -72,11 +72,11 @@ This output tells you the following:
 
 Kraken-wrapper supports different installers that can materialize your build environment. The default is `VENV` which uses the `venv` module from the Python standard library to create a virtual environment and then `pip` to install requirements.
 
-Since `v0.34.0`, Kraken-wrapper also supports the `UV` installer which uses [uv](https://astral.sh/blog/uv) to create the virtual environment and install requirements. Uv is a new project in its early stages, but is generally faster than the `VENV` installer by a factor of 10-20x. To use the `UV` installer, you have the following options:
+Since `v0.34.0`, Kraken-wrapper also supports the `UV` installer which uses [uv](https://astral.sh/blog/uv) to create the virtual environment and install requirements. In `v0.40.5`, `UV` was set to the default installer, replacing `VENV`, as it is generally faster than the `VENV` installer by a factor of 10-20x. To use the legacy `VENV` installer, you have the following options:
 
-1. Set the `KRAKENW_USE=UV` environment variable.
-2. Pass the `--use=UV` option to the `krakenw` command when installing your environment.
-3. Run `krakenw config --installer=UV` to set UV as the default installer in `~/.config/krakenw/config.toml`.
+1. Set the `KRAKENW_USE=VENV` environment variable.
+2. Pass the `--use=VENV` option to the `krakenw` command when installing your environment.
+3. Run `krakenw config --installer=VENV` to set venv as the default installer in `~/.config/krakenw/config.toml`.
 
 ## Credentials managment
 

--- a/kraken-wrapper/src/kraken/wrapper/_option_sets.py
+++ b/kraken-wrapper/src/kraken/wrapper/_option_sets.py
@@ -28,7 +28,7 @@ class EnvOptions:
             help="use the specified environment type. If the environment type changes it will trigger a reinstall.\n"
             "Defaults to the value of the KRAKENW_USE environment variable. If that variable is unset, and\nif a build "
             "environment already exists, that environment's type will be used. The default\nenvironment type that is "
-            "used for new environments is VENV. [env: KRAKENW_USE=...]",
+            "used for new environments is UV. [env: KRAKENW_USE=...]",
         )
         group.add_argument(
             "--status",


### PR DESCRIPTION
This is a follow up to https://github.com/kraken-build/kraken/pull/281/ that documents that UV is now the default installer type, superseding the VENV installer.