### PR TITLE
Fix error in `krakenw` if no requirements are specified in `buildscript()` and update examples CI to run with both `krakenw` and `kraken`

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,10 @@ id = "e64939c7-c061-46c3-a148-a81a2b0a4e97"
 type = "deprecation"
 description = "Deprecate Maturin + PDM project support"
 author = "thomas.pellissier-tanon@helsing.ai"
+
+[[entries]]
+id = "39a47d11-7858-44c9-ab41-4f4c128e86e5"
+type = "fix"
+description = "Fix error when calling `uv pip install` when no requirements are specified in `buildscript()` call. (It will error later when it cannot call Kraken, but that is a better error)"
+author = "@NiklasRosenstein"
+component = "kraken-wrapper"

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -157,13 +157,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        call-target: ["krakenw", "kraken"]
     steps:
     - uses: actions/checkout@v4
     - uses: NiklasRosenstein/slap@gha/install/v1
     - uses: actions/setup-python@v5
       with: { python-version: "${{ matrix.python-version }}" }
     - run: slap config --venv-type=uv && slap install --link --no-venv-check ${{ matrix.only }}
-    - run: cd examples/docker-manual && kraken run :dockerBuild :sub:helloWorld
+    - run: cd examples/docker-manual && ${{ matrix.call-target }} run :dockerBuild :sub:helloWorld
 
   publish:
     runs-on: ubuntu-latest

--- a/examples/docker-manual/.kraken.py
+++ b/examples/docker-manual/.kraken.py
@@ -1,5 +1,7 @@
+## ::krakenw-root
+
 from kraken.common import buildscript
-buildscript(additional_sys_paths=["."])
+buildscript(requirements=["kraken-build @ ../../kraken-wrapper"], additional_sys_paths=["."])
 
 from kraken.build import project
 from my_tasks import WriteDockerfileTask, DockerBuildTask

--- a/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
@@ -103,7 +103,7 @@ class VenvBuildEnv(BuildEnv):
                 "'%s' failed (exit code: %d, command: %s). Check the output above for more information.",
                 operation_name,
                 exc.returncode if isinstance(exc, subprocess.CalledProcessError) else -1,
-                "$ " + command_str,
+                command_str,
             )
 
         raise BuildEnvError(f"The command failed: {command_str}") from exc

--- a/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
@@ -216,7 +216,7 @@ class VenvBuildEnv(BuildEnv):
 
         # Install requirements.
         if not requirements.requirements:
-            logger.info("No requirements specfied, skipping install step.")
+            logger.info("No requirements specified, skipping install step.")
         else:
             env = os.environ.copy()
             command = self._get_install_command(self._path, requirements, env)

--- a/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
@@ -215,15 +215,18 @@ class VenvBuildEnv(BuildEnv):
             logger.info("Reusing virtual environment at %s", self._path)
 
         # Install requirements.
-        env = os.environ.copy()
-        command = self._get_install_command(self._path, requirements, env)
-        logger.info("Installing dependencies.")
-        logger.debug(
-            "Installing into build environment with %s: %s",
-            self.INSTALLER_NAME,
-            sanitize_http_basic_auth(" ".join(command)),
-        )
-        self._run_command(command, operation_name="Install dependencies", log_file=install_log, env=env)
+        if not requirements.requirements:
+            logger.info("No requirements specfied, skipping install step.")
+        else:
+            env = os.environ.copy()
+            command = self._get_install_command(self._path, requirements, env)
+            logger.info("Installing dependencies.")
+            logger.debug(
+                "Installing into build environment with %s: %s",
+                self.INSTALLER_NAME,
+                sanitize_http_basic_auth(" ".join(command)),
+            )
+            self._run_command(command, operation_name="Install dependencies", log_file=install_log, env=env)
 
         # Make sure the pythonpath from the requirements is encoded into the enviroment.
         self._install_pythonpath(self._path, list(requirements.pythonpath))

--- a/kraken-wrapper/src/kraken/wrapper/main.py
+++ b/kraken-wrapper/src/kraken/wrapper/main.py
@@ -360,7 +360,7 @@ def load_project(directory: Path, outdated_check: bool = True) -> Project:
     and returns it. The project information includes the requirements for the project as well as the
     parsed lockfile, if present.
 
-    We use the :class:`GitAwareProjectFinder` in it's :func:`default <GitAwareProjectFinder.default>`
+    We use the :class:`GitAwareProjectFinder` in its :func:`default <GitAwareProjectFinder.default>`
     configuration to determine the root directory of the Kraken project. This is later used to add the
     ``-p, --project-dir`` option when invoking the project's underlying Kraken installation, as well as
     adding to relative task and project selectors.

--- a/kraken-wrapper/src/kraken/wrapper/main.py
+++ b/kraken-wrapper/src/kraken/wrapper/main.py
@@ -360,6 +360,30 @@ def load_project(directory: Path, outdated_check: bool = True) -> Project:
     and returns it. The project information includes the requirements for the project as well as the
     parsed lockfile, if present.
 
+    We use the :class:`GitAwareProjectFinder` in it's :func:`default <GitAwareProjectFinder.default>`
+    configuration to determine the root directory of the Kraken project. This is later used to add the
+    ``-p, --project-dir`` option when invoking the project's underlying Kraken installation, as well as
+    adding to relative task and project selectors.
+
+    For example, in the following project:
+
+    .. code-block::
+
+        /
+            .git/
+            .kraken.py
+            examples/           << cwd
+                .kraken.py
+            src/
+
+    Running ``krakenw run test-examples`` will translate into ``kraken run -p .. examples:test-examples``
+    due to the :class:`GitAwareProjectFinder` finding ``/`` as the Kraken project root.
+
+    Note that if the ``examples/`` wanted to be its own Kraken project, independant of the project at ``//``,
+    you can add a line spelling ``# ::krakenw-root`` to the ``.kraken.py`` file. In that case, the
+    :class:`GitAwareProjectFinder` will consider that directory the root Kraken project (assuming your CWD
+    is somewhere within it).
+
     :param directory: The directory for which to load the build project details for.
     :param outdated_check: If enabled, performs a check to see if the requirements that the lockfile was
         generated with is outdated compared to the project requirements.


### PR DESCRIPTION
Also improved the documentation of `kraken.wrapper.main.load_project()`