### PR TITLE
Use Mise; run `typos` in CI and fix typos

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "e64939c7-c061-46c3-a148-a81a2b0a4e97"
 type = "deprecation"
 description = "Deprecate Maturin + PDM project support"
 author = "thomas.pellissier-tanon@helsing.ai"
+
+[[entries]]
+id = "dbb56b0e-6634-4c45-ae99-3936c397b12a"
+type = "improvement"
+description = "Run `typos` in CI and fix typos in codebase"
+author = "@NiklasRosenstein"

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -49,6 +49,13 @@ jobs:
 
   # == Unit tests, linting, and type checking ==
 
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: jdx/mise-action@v2
+    - run: typos
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -21,10 +21,7 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
-    - uses: NiklasRosenstein/slap@gha/install/v1
-
-    - run: pipx install kraken-wrapper==0.34.1 && krakenw config --installer=UV
-    - run: pipx install mksync
+    - uses: jdx/mise-action@v2
 
     - name: Restore Kraken build cache
       uses: actions/cache/restore@v4
@@ -32,11 +29,7 @@ jobs:
         path: build
         key: build-cache:${{ runner.os }}:${{ hashFiles('.kraken.lock') }}
 
-    - run: |
-        cd docs
-        for fn in docs/cli/*.md; do mksync -i $fn; done
-        mksync -i docs/changelog.md
-    - run: krakenw run mkdocs.build --no-save
+    - run: mise run build-docs
 
     - name: Save Kraken build cache
       uses: actions/cache/save@v4
@@ -65,11 +58,13 @@ jobs:
         tasks: ["check lint", "test"]
     steps:
     - uses: actions/checkout@v4
-    - uses: NiklasRosenstein/slap@gha/install/v1
+    - uses: jdx/mise-action@v2
     - uses: actions/setup-python@v5
       with: { python-version: "${{ matrix.python-version }}" }
-    - run: pip install pipx && pipx install poetry && pipx install pdm && pipx install uv && pipx install kraken-wrapper==0.34.1 && krakenw config --installer=UV
+
+    # We have Rust code in the examples/ which will be built as part of our tests.
     - run: rustup update
+
     - run: slap config --venv-type=uv
 
     - name: Restore Kraken build cache
@@ -159,7 +154,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
-    - uses: NiklasRosenstein/slap@gha/install/v1
+    - uses: jdx/mise-action@v2
     - uses: actions/setup-python@v5
       with: { python-version: "${{ matrix.python-version }}" }
     - run: slap config --venv-type=uv && slap install --link --no-venv-check ${{ matrix.only }}
@@ -175,7 +170,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: NiklasRosenstein/slap@gha/install/v1
+      - uses: jdx/mise-action@v2
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-identifiers]
+CommitedFileStatus = "CommitedFileStatus"

--- a/docs/docs/krakenw.md
+++ b/docs/docs/krakenw.md
@@ -78,7 +78,7 @@ Since `v0.34.0`, Kraken-wrapper also supports the `UV` installer which uses [uv]
 2. Pass the `--use=UV` option to the `krakenw` command when installing your environment.
 3. Run `krakenw config --installer=UV` to set UV as the default installer in `~/.config/krakenw/config.toml`.
 
-## Credentials managment
+## Credentials management
 
 The `krakenw auth` command can be used to store credentials for a given hostname in the system keyring. Any `index_url` or `extra_index_url` in your build script's requirements that matches the hostname will use these credentials to authenticate with the package index.
 

--- a/docs/docs/lang/python.md
+++ b/docs/docs/lang/python.md
@@ -27,7 +27,7 @@ create a virtual environment and install the project into it).
 Build systems implemented for Kraken will take care of the installation, ensuring that the Python package indexes
 registered in the build script are made available to the installation process.
 
-Kraken assumes that these package managers or build systems are installed locally by the user and accesible in the `$PATH`.
+Kraken assumes that these package managers or build systems are installed locally by the user and accessible in the `$PATH`.
 If you use a custom installation, make sure these tools are available in there.
 
 ### Poetry

--- a/docs/docs/lang/python.md
+++ b/docs/docs/lang/python.md
@@ -38,7 +38,7 @@ If you use a custom installation, make sure these tools are available in there.
 
 ### Slap
 
-* **Package index credentials**: [TODO] The installation processs passes the extra index URLs to `slap install` using the
+* **Package index credentials**: [TODO] The installation process passes the extra index URLs to `slap install` using the
 `--package-index` option.
   * [TODO] Should we add an option to permanently add a package index to the Slap configuration and then keep it in
     sync with a task?

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -47,7 +47,7 @@ class Requirement(abc.ABC):
 
 @dataclasses.dataclass(frozen=True)
 class PipRequirement(Requirement):
-    """Represents a Pip requriement."""
+    """Represents a Pip requirement."""
 
     name: str
     spec: str | None

--- a/kraken-build/src/kraken/common/findpython.py
+++ b/kraken-build/src/kraken/common/findpython.py
@@ -233,7 +233,7 @@ def evaluate_candidates(
 
 def print_interpreters(interpreters: Iterable[Interpreter]) -> None:
     """
-    Prints the interpeter information to stdout, colored.
+    Prints the interpreter information to stdout, colored.
     """
 
     from kraken.common import Color, colored

--- a/kraken-build/src/kraken/common/graphviz.py
+++ b/kraken-build/src/kraken/common/graphviz.py
@@ -92,7 +92,7 @@ class GraphvizWriter:
         self._out.write(";\n")
 
     def edge(self, source: str | t.Sequence[str], target: str | t.Sequence[str], **attrs: str | None) -> None:
-        """Draw one or multiple edges in the current contect from source to target. Specifying multiple
+        """Draw one or multiple edges in the current context from source to target. Specifying multiple
         nodes on either side will generate the cross product of edges between all nodes."""
         if isinstance(source, str):
             source = [source]

--- a/kraken-build/src/kraken/common/graphviz.py
+++ b/kraken-build/src/kraken/common/graphviz.py
@@ -18,7 +18,7 @@ class GraphvizWriter:
     def __init__(self, out: t.TextIO, indent: str = "\t") -> None:
         """
         :param out: The output file to write to.
-        :param indent: The string to use for every level of indendation.
+        :param indent: The string to use for every level of indentation.
         """
 
         self._out = out
@@ -72,7 +72,7 @@ class GraphvizWriter:
         self._edge_type.append(self._edge_type[-1])
 
     def end(self) -> None:
-        """Close a previouly opened block. Raises an :class:`AssertionError` if called too many times."""
+        """Close a previously opened block. Raises an :class:`AssertionError` if called too many times."""
         assert self._level >= 1, "called end() too many times"
         self._level -= 1
         self._edge_type.pop()

--- a/kraken-build/src/kraken/common/http/lint_ban_bare_requests.py
+++ b/kraken-build/src/kraken/common/http/lint_ban_bare_requests.py
@@ -60,7 +60,7 @@ class BareCallsVisitor(ast.NodeVisitor):
 
 class BanBareCalls:
     """
-    Detects occurences of bare httpx or requests function calls.
+    Detects occurrences of bare httpx or requests function calls.
     These are discouraged, as using the corresponding calls from the kraken.common.http usually work better
     in corporate networks.
     """

--- a/kraken-build/src/kraken/common/path.py
+++ b/kraken-build/src/kraken/common/path.py
@@ -20,7 +20,7 @@ def is_relative_to(apath: Path, bpath: Path) -> bool:
 def try_relative_to(apath: Path, bpath: "Path | None" = None) -> Path:
     """
     Tries to compute the relative path of *apath* relative to *bpath*. Returns the original *apath* if the
-    relative path can be be computed, for exmaple if we would need to go at least one directory up to reach
+    relative path can be be computed, for example if we would need to go at least one directory up to reach
     *apath* relative to *bpath*.
     """
 

--- a/kraken-build/src/kraken/core/address/_address.py
+++ b/kraken-build/src/kraken/core/address/_address.py
@@ -116,7 +116,7 @@ class Address(metaclass=AddressMeta):
     The elements of an address can only contain characters matching the :data:`Address.Element.VALIDATION_REGEX`.
 
     Asterisks are accepted to permit glob pattern matching on the addressable space, where one asterisk (`*`) is
-    intended to match only within the same hierarchical level (aka. wildcard), wheras a double asterisk (`**`) is
+    intended to match only within the same hierarchical level (aka. wildcard), whereas a double asterisk (`**`) is
     used to match any number of levels (aka. recursive wildcard). A trailing question mark on each element is allowed
     to permit that address resolution fails at that element.
 
@@ -575,7 +575,7 @@ class Address(metaclass=AddressMeta):
             >>> Address("..").parent
             Address('..:..')
 
-        The container status of the address is perserved.
+        The container status of the address is preserved.
 
             >>> Address(":a:b").parent
             Address(':a')

--- a/kraken-build/src/kraken/core/address/_address_resolver_test.py
+++ b/kraken-build/src/kraken/core/address/_address_resolver_test.py
@@ -124,20 +124,20 @@ def test__resolve_address__does_not_fail_on_optional_element() -> None:
     tree = ExampleNodeTree()
     space = NodeAddressSpace(tree.root)
 
-    # We can sucessfully resolve :a:b? to :a:b.
+    # We can successfully resolve :a:b? to :a:b.
     assert list(resolve_address(space, tree.root, Address(":a:b?")).matches()) == [tree.ab]
 
-    # We can sucessfully resolve :a:dontexist? to nothing, as the address does not exist.
+    # We can successfully resolve :a:dontexist? to nothing, as the address does not exist.
     assert list(resolve_address(space, tree.root, Address(":a:dontexist?")).matches()) == []
 
     # Try to resolve :a:dontexist without an optional element fails.
     with raises(AddressResolutionError):
         list(resolve_address(space, tree.root, Address(":a:dontexist")).matches())
 
-    # We can sucessfully resolve :a:b?:a to :a:b:a.
+    # We can successfully resolve :a:b?:a to :a:b:a.
     assert list(resolve_address(space, tree.root, Address(":a:b?:a")).matches()) == [tree.aba]
 
-    # We can sucessfully resolve :a:b?:dontexist to nothing, as the element that does not exist is optional.
+    # We can successfully resolve :a:b?:dontexist to nothing, as the element that does not exist is optional.
     assert list(resolve_address(space, tree.root, Address(":a:b:dontexist?")).matches()) == []
 
     # It is also okay to resolve :a::missing1?:missing to nothing, because we won't try to look up the missing2

--- a/kraken-build/src/kraken/core/cli/main.py
+++ b/kraken-build/src/kraken/core/cli/main.py
@@ -140,7 +140,7 @@ def _load_build_state(
         )
 
     # For consistency, we always act as if Kraken was run from the project root directory.
-    # Using the `subproject_directory`, we later fitler down which tasks are selected / how relative
+    # Using the `subproject_directory`, we later filter down which tasks are selected / how relative
     # task references on the CLI are resolved.
     os.chdir(root_directory)
 
@@ -570,7 +570,7 @@ def env() -> None:
 
 def on_exception(exc: BaseException) -> int:
     """
-    Called when an exception occurrs in #main_internal() to handle common errors and provide better error messages.
+    Called when an exception occurs in #main_internal() to handle common errors and provide better error messages.
     """
 
     issues_url = "https://github.com/kraken-build/kraken-build/issues"

--- a/kraken-build/src/kraken/core/system/context.py
+++ b/kraken-build/src/kraken/core/system/context.py
@@ -89,7 +89,7 @@ class Context(MetadataContainer, Currentable["Context"]):
         observer: GraphExecutorObserver | None = None,
     ) -> None:
         """
-        :param build_directory: The directory in which all files generated durin the build should be stored.
+        :param build_directory: The directory in which all files generated during the build should be stored.
         :param project_finder: This project finder should only search within the directory it was given, not
             around or in parent folders. Defaults to :class:`CurrentDirectoryProjectFinder`.
         :param executor: The executor to use when the graph is executed.

--- a/kraken-build/src/kraken/core/system/executor/default_test.py
+++ b/kraken-build/src/kraken/core/system/executor/default_test.py
@@ -58,7 +58,7 @@ def trim_printed_result(captured: CaptureResult[str]) -> str:
 def test__DefaultExecutor__print_correct_failures_with_dependencies(
     kraken_project: Project, capsys: Generator[CaptureFixture[str], None, None]
 ) -> None:
-    """This test tests if when a task failed, successor tasks with depedencies will be printed as failed.
+    """This test tests if when a task failed, successor tasks with dependencies will be printed as failed.
 
     ```
     A -> B -> C -> D

--- a/kraken-build/src/kraken/core/system/graph.py
+++ b/kraken-build/src/kraken/core/system/graph.py
@@ -425,7 +425,7 @@ class TaskGraph(Graph):
         :param reason: A reason to attach to the `"skip"` tag.
         :param origin: An origin to attach to the `"skip"` tag.
         :param reset: Enable this to remove the `"skip"` tags of the same *origin* are removed from all mentioned
-            tasks (including transtive dependencies for *recursive_tasks*) the graph first. Note that this does not
+            tasks (including transitive dependencies for *recursive_tasks*) the graph first. Note that this does not
             unset any pre-existing task statuses.
         """
 
@@ -459,7 +459,7 @@ class TaskGraph(Graph):
         # (2) We mark the subgraphs (i.e. predecessors) of all recursive_tasks with the color "blue". These are tasks
         #     that can potentially be skipped as well, but we are not sure yet.
         #
-        # (3) We walk back through the entire task graph from its leafs, discoloring any "blue" task that we encounter.
+        # (3) We walk back through the entire task graph from its leaves, discoloring any "blue" task that we encounter.
         #     If we encounter a "red" task, we keep it colored and ignore its subgraph.
 
         red_tasks = {*tasks, *recursive_tasks}

--- a/kraken-build/src/kraken/core/system/graph_test.py
+++ b/kraken-build/src/kraken/core/system/graph_test.py
@@ -330,7 +330,7 @@ def test__TaskGraph__mark_tasks_as_skipped__does_not_skip_task_required_by_anoth
     assert [t.name for t in c.get_tags("skip")] == []
 
 
-def test__TaskGraph__mark_tasks_as_skipped__does_skip_task_if_requierd_by_another_skipped_task(
+def test__TaskGraph__mark_tasks_as_skipped__does_skip_task_if_required_by_another_skipped_task(
     kraken_project: Project, caplog: Any
 ) -> None:
     """This test builds a TaskGraph that would have the `mark_tasks_as_skipped()` method pass through a recursively

--- a/kraken-build/src/kraken/core/system/project.py
+++ b/kraken-build/src/kraken/core/system/project.py
@@ -112,7 +112,7 @@ class Project(KrakenObject, MetadataContainer, Currentable["Project"]):
     @property
     def build_directory(self) -> Path:
         """Returns the recommended build directory for the project; this is a directory inside the context
-        build directory ammended by the project name."""
+        build directory amended by the project name."""
 
         return self.context.build_directory / str(self.address).replace(":", "/").lstrip("/")
 

--- a/kraken-build/src/kraken/core/system/property_test.py
+++ b/kraken-build/src/kraken/core/system/property_test.py
@@ -9,7 +9,7 @@ from kraken.common.supplier import OfSupplier, VoidSupplier
 from kraken.core.system.property import Property, PropertyContainer
 
 
-def test__Property_value_adapter_order_is_semantically_revelant() -> None:
+def test__Property_value_adapter_order_is_semantically_relevant() -> None:
     """Tests that a `str | Path` and `Path | str` property behave differently."""
 
     prop1: Property[str | Path] = Property(PropertyContainer(), "prop1", Union[str, Path])

--- a/kraken-build/src/kraken/core/system/task.py
+++ b/kraken-build/src/kraken/core/system/task.py
@@ -182,7 +182,7 @@ class Task(KrakenObject, PropertyContainer, abc.ABC):
     """
     A Kraken Task is a unit of work that can be executed.
 
-    Tasks goe through a number of stages during its lifetime:
+    Tasks go through a number of stages during its lifetime:
 
     * Creation and configuration
     * Finalization (:meth:`finalize`) -- Mutations to properties of the task are locked after this.

--- a/kraken-build/src/kraken/std/cargo/tasks/cargo_publish_task.py
+++ b/kraken-build/src/kraken/std/cargo/tasks/cargo_publish_task.py
@@ -24,7 +24,7 @@ class CargoPublishTask(CargoBuildTask):
     #: Path to the Cargo configuration file (defaults to `.cargo/config.toml`).
     cargo_config_file: Property[Path] = Property.default(".cargo/config.toml")
 
-    #: Name of the package to publish (only requried for publishing packages from workspace)
+    #: Name of the package to publish (only required for publishing packages from workspace)
     package_name: Property[str | None] = Property.default(None)
 
     #: The registry to publish the package to.

--- a/kraken-build/src/kraken/std/cargo/tasks/cargo_publish_task.py
+++ b/kraken-build/src/kraken/std/cargo/tasks/cargo_publish_task.py
@@ -156,7 +156,7 @@ class CargoPublishTask(CargoBuildTask):
     @classmethod
     def _check_package_existence(cls, package_name: str, version: str, registry: CargoRegistry) -> TaskStatus | None:
         """
-        Checks wether the given `package_name`@`version` is indexed in the provided `registry`.
+        Checks whether the given `package_name`@`version` is indexed in the provided `registry`.
 
         Checking is done by reading from the registry's index HTTP API, following the
         [Index Format](https://doc.rust-lang.org/cargo/reference/registry-index.html) documentation

--- a/kraken-build/src/kraken/std/docker/tasks/base_build_task.py
+++ b/kraken-build/src/kraken/std/docker/tasks/base_build_task.py
@@ -7,7 +7,7 @@ from kraken.std.util.render_file_task import RenderFileTask, render_file
 
 class BaseBuildTask(Task):
     """Base class for tasks that build Docker images. Subclasses implement converting the task properties into
-    the invokation for a Docker build backend."""
+    the invocation for a Docker build backend."""
 
     build_context: Property[Path]
     dockerfile: Property[Path] = Property.default(Path("Dockerfile"))

--- a/kraken-build/src/kraken/std/git/__init__.py
+++ b/kraken-build/src/kraken/std/git/__init__.py
@@ -73,7 +73,7 @@ def gitignore_extend(
     Extend the Gitignore task's generated content section by the given *pattern*s.
 
     Args:
-        project: The project to look for the Gitignore task configuraton in. If it is not specified, it will be
+        project: The project to look for the Gitignore task configuration in. If it is not specified, it will be
                  searched in the currently active project and any of its parents (often the Gitignore tasks only exist
                  on the root project).
         patterns: The patterns to add to the config.

--- a/kraken-build/src/kraken/std/git/gitignore/gitignore_io_test.py
+++ b/kraken-build/src/kraken/std/git/gitignore/gitignore_io_test.py
@@ -7,7 +7,7 @@ def test__gitignore_io_cache_for_every_token() -> None:
     assert set(load_token_cache()) == set(TOKENS)
 
 
-def test__gitignore_io_fetch_cached__errors_without_backfil_on_missing_token() -> None:
+def test__gitignore_io_fetch_cached__errors_without_backfill_on_missing_token() -> None:
     with pytest.raises(ValueError) as excinfo:
         gitignore_io_fetch_cached(["missing-token"], backfill=False)
     assert str(excinfo.value) == (

--- a/kraken-build/src/kraken/std/git/tasks/check_file_task.py
+++ b/kraken-build/src/kraken/std/git/tasks/check_file_task.py
@@ -9,37 +9,41 @@ from kraken.core import Property, Task, TaskStatus
 from kraken.core.system.task import TaskStatusType
 
 
-def check_file_status(file_path: Path) -> CommitedFileStatus:
+def check_file_status(file_path: Path) -> CommittedFileStatus:
     file_path = file_path.absolute()
     if not file_path.exists():
-        return CommitedFileStatus.MISSING
+        return CommittedFileStatus.MISSING
     ls_files = subprocess.run(
         ["git", "ls-files", "--", str(file_path)], capture_output=True, text=True, cwd=file_path.parent
     ).stdout.strip()
     if ls_files != file_path.name:
-        return CommitedFileStatus.NOT_COMMITTED
-    return CommitedFileStatus.COMMITED
+        return CommittedFileStatus.NOT_COMMITTED
+    return CommittedFileStatus.COMMITTED
 
 
-class CommitedFileStatus(enum.Enum):
+class CommittedFileStatus(enum.Enum):
     """
-    Represents the status of a file that is supposed to be commited.
+    Represents the status of a file that is supposed to be committed.
     """
 
-    COMMITED = enum.auto()
+    COMMITTED = enum.auto()
     NOT_COMMITTED = enum.auto()
     MISSING = enum.auto()
 
     def to_description(self, file_path: Path) -> str:
         match self:
-            case CommitedFileStatus.COMMITED:
+            case CommittedFileStatus.COMMITTED:
                 return f"'{file_path}' exists and is committed"
-            case CommitedFileStatus.NOT_COMMITTED:
+            case CommittedFileStatus.NOT_COMMITTED:
                 return f"'{file_path}' exists but is not committed"
-            case CommitedFileStatus.MISSING:
+            case CommittedFileStatus.MISSING:
                 return f"'{file_path}' does not exist"
             case _:
                 assert False
+
+
+# For backwards compatibility; typo was fixed in v0.45.0
+CommitedFileStatus = CommittedFileStatus
 
 
 class CheckFileTask(Task):
@@ -62,9 +66,9 @@ class CheckFileTask(Task):
         status = check_file_status(self.project.directory / self.file_to_check.get())
         success: bool
         match status:
-            case CommitedFileStatus.COMMITED:
+            case CommittedFileStatus.COMMITTED:
                 success = self.state.get() == "present"
-            case CommitedFileStatus.NOT_COMMITTED | CommitedFileStatus.MISSING:
+            case CommittedFileStatus.NOT_COMMITTED | CommittedFileStatus.MISSING:
                 success = self.state.get() != "present"
             case _:
                 assert False, f"Unknown status: {status}"

--- a/kraken-build/src/kraken/std/mitm/__init__.py
+++ b/kraken-build/src/kraken/std/mitm/__init__.py
@@ -31,7 +31,7 @@ def start_mitmweb_proxy(
 ) -> tuple[str, Path]:
     """
     Ensure that a `mitmweb` process with the given *auth* configuration and *additional_args* is running. If a
-    process is already running that doens't match the spec, it will be stopped and a new one will be started.
+    process is already running that doesn't match the spec, it will be stopped and a new one will be started.
 
     Note:
         This process is managed globally and the state is stored under `~/.mitmproxy`. Switching between projects

--- a/kraken-build/src/kraken/std/python/__init__.py
+++ b/kraken-build/src/kraken/std/python/__init__.py
@@ -19,7 +19,7 @@ from .tasks.update_lockfile_task import update_lockfile_task
 from .tasks.update_pyproject_task import update_pyproject_task
 from .version import git_version_to_python_version
 
-# Backwards compatibilty
+# Backwards compatibility
 git_version_to_python = git_version_to_python_version
 
 __all__ = [

--- a/kraken-build/src/kraken/std/python/buildsystem/__init__.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/__init__.py
@@ -51,7 +51,7 @@ class PythonBuildSystem(abc.ABC):
     @abc.abstractmethod
     def update_lockfile(self, settings: PythonSettings, pyproject: TomlFile) -> TaskStatus:
         """Resolve all dependencies of the project and write the exact versions into
-        the correspondig lock file. In the case of Poetry it is poetry.lock."""
+        the corresponding lock file. In the case of Poetry it is poetry.lock."""
 
     @abc.abstractmethod
     def requires_login(self) -> bool:

--- a/kraken-build/src/kraken/std/python/buildsystem/pdm.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/pdm.py
@@ -23,7 +23,7 @@ from . import ManagedEnvironment, PythonBuildSystem
 logger = logging.getLogger(__name__)
 
 # NOTE: We can't inline this expression where we need it because Mypy understands the expression and will permanently
-#       turn off a code path on the corresponding systme, which can lead to type errors downstream (typically
+#       turn off a code path on the corresponding system, which can lead to type errors downstream (typically
 #       unreachable code).
 _is_linux = sys.platform == "linux"
 

--- a/kraken-build/src/kraken/std/util/daemon_controller.py
+++ b/kraken-build/src/kraken/std/util/daemon_controller.py
@@ -245,7 +245,7 @@ class DaemonController:
         logger.debug("Spawning fork to start daemon %s", self.name)
         pid = spawn_fork(start_daemon)
         if status := wait_for_child_process(pid, 10.0):
-            raise Exception("An unexpected error ocurred when starting daemon %r (exit code %s).", self.name, status)
+            raise Exception("An unexpected error occurred when starting daemon %r (exit code %s).", self.name, status)
         return True
 
     def stop(self) -> bool:

--- a/kraken-wrapper/src/kraken/wrapper/_buildenv_manager.py
+++ b/kraken-wrapper/src/kraken/wrapper/_buildenv_manager.py
@@ -38,7 +38,7 @@ class BuildEnvManager:
 
         assert (
             default_hash_algorithm in hashlib.algorithms_available
-        ), f"hash algoritm {default_hash_algorithm!r} is not available"
+        ), f"hash algorithm {default_hash_algorithm!r} is not available"
 
         self._project_root = project_root
         self._path = path

--- a/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/_buildenv_venv.py
@@ -113,7 +113,7 @@ class VenvBuildEnv(BuildEnv):
         return [str(python_bin), "-m", "venv", str(path), "--upgrade-deps"]
 
     def _get_install_command(self, venv_dir: Path, requirements: RequirementSpec, env: dict[str, str]) -> list[str]:
-        """Return sthe command to install the given requirements into the virtual environment."""
+        """Return the command to install the given requirements into the virtual environment."""
         python_bin = venv_dir / "bin" / "python"
         command = [
             str(python_bin),
@@ -225,7 +225,7 @@ class VenvBuildEnv(BuildEnv):
         )
         self._run_command(command, operation_name="Install dependencies", log_file=install_log, env=env)
 
-        # Make sure the pythonpath from the requirements is encoded into the enviroment.
+        # Make sure the pythonpath from the requirements is encoded into the environment.
         self._install_pythonpath(self._path, list(requirements.pythonpath))
 
     def dispatch_to_kraken_cli(self, argv: list[str]) -> NoReturn:

--- a/kraken-wrapper/src/kraken/wrapper/_option_sets.py
+++ b/kraken-wrapper/src/kraken/wrapper/_option_sets.py
@@ -146,7 +146,7 @@ class AuthOptions:
             "--verbose",
             action="store_true",
             default=False,
-            help="show curl queries to use when authenicating hosts",
+            help="show curl queries to use when authenticating hosts",
         )
 
     @classmethod

--- a/kraken-wrapper/src/kraken/wrapper/main.py
+++ b/kraken-wrapper/src/kraken/wrapper/main.py
@@ -379,7 +379,7 @@ def load_project(directory: Path, outdated_check: bool = True) -> Project:
     Running ``krakenw run test-examples`` will translate into ``kraken run -p .. examples:test-examples``
     due to the :class:`GitAwareProjectFinder` finding ``/`` as the Kraken project root.
 
-    Note that if the ``examples/`` wanted to be its own Kraken project, independant of the project at ``//``,
+    Note that if the ``examples/`` wanted to be its own Kraken project, independent of the project at ``//``,
     you can add a line spelling ``# ::krakenw-root`` to the ``.kraken.py`` file. In that case, the
     :class:`GitAwareProjectFinder` will consider that directory the root Kraken project (assuming your CWD
     is somewhere within it).

--- a/kraken-wrapper/src/kraken/wrapper/main.py
+++ b/kraken-wrapper/src/kraken/wrapper/main.py
@@ -106,7 +106,7 @@ def lock(prog: str, argv: list[str], manager: BuildEnvManager, project: Project)
         extra_distributions.discard("pip")  # We'll always have that in a virtual env.
 
     if extra_distributions:
-        logger.warning("Found extra distributions in your Kraken build enviroment: %s", ", ".join(extra_distributions))
+        logger.warning("Found extra distributions in your Kraken build environment: %s", ", ".join(extra_distributions))
 
     had_lockfile = project.lockfile_path.exists()
     lockfile.write_to(project.lockfile_path)
@@ -240,7 +240,7 @@ def list_pythons(prog: str, argv: list[str]) -> NoReturn:
 
 
 def _print_env_status(manager: BuildEnvManager, project: Project) -> None:
-    """Print the status of the environent as a nicely formatted table."""
+    """Print the status of the environment as a nicely formatted table."""
 
     hash_algorithm = manager.get_hash_algorithm()
 
@@ -428,7 +428,7 @@ def main(krakenw_args: list[str] | None = None) -> NoReturn:
     argv: list[str] = args.cmd[1:] + args.args
 
     if cmd in ("a", "auth"):
-        # The `auth` comand does not require any current project information, it can be used globally.
+        # The `auth` command does not require any current project information, it can be used globally.
         auth(f"{parser.prog} auth", argv, use_keyring_if_available=not env_options.no_keyring)
 
     if cmd in ("config",):

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,20 @@
+[tools]
+"pipx:kraken-wrapper" = "0.34.1"
+"pipx:mksync" = "0.1.4"
+"pipx:pdm" = "2.25.4"
+"pipx:poetry" = "2.1.3"
+"pipx:slap-cli" = "1.15.0"
+uv = "0.7.13"
+
+[tasks.update-docs]
+description = "Run `mksync` over doc files to inject command synopses and generate the changelog."
+run = """bash -c '
+set -x
+cd docs
+for fn in docs/cli/*.md; do uv run mksync -i $fn; done
+uv run mksync -i docs/changelog.md
+'"""
+
+[tasks.build-docs]
+depends = ["update-docs"]
+run = "krakenw run mkdocs.build --no-save -vv"

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@
 "pipx:pdm" = "2.25.4"
 "pipx:poetry" = "2.1.3"
 "pipx:slap-cli" = "1.15.0"
+typos = "1.33.1"
 uv = "0.7.13"
 
 [tasks.update-docs]


### PR DESCRIPTION
This CI fixes typos uncovered by the `typos` tool, and runs it in CI. To use typos, I started adding Mise to the repo.

Mise is a neat tool to install dev tools in your project. It'll make it easier to get started working in the repository as it stores in the `mise.toml` all the tools you need. It also simplifies the CI a little bit.

