### PR TITLE
fix: `krakenw --upgrade` now passes the `--upgrade` flag to `uv pip install`, as expected

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "aa2cba40-ff5c-42b0-a1b8-636f522db101"
+type = "fix"
+description = "`krakenw --upgrade` now passes the `--upgrade` flag to `uv pip install`, as expected"
+author = "@NiklasRosenstein"

--- a/kraken-wrapper/src/kraken/wrapper/main.py
+++ b/kraken-wrapper/src/kraken/wrapper/main.py
@@ -309,7 +309,7 @@ def _ensure_installed(
         )
 
         tstart = time.perf_counter()
-        manager.install(source, reinstall)
+        manager.install(source, reinstall, upgrade)
         duration = time.perf_counter() - tstart
         logger.info("Operation complete after %.3fs.", duration)
 

--- a/kraken-wrapper/src/kraken/wrapper/uv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/uv_venv.py
@@ -97,6 +97,7 @@ class UvVirtualEnv:
         requirements: Iterable[str],
         index_url: str | None = None,
         extra_index_urls: Sequence[str] = (),
+        upgrade: bool = False,
     ) -> None:
         """
         Performs an exact install of the given requirements into the environment.
@@ -115,6 +116,8 @@ class UvVirtualEnv:
             command += ["--index-url", index_url]
         for url in extra_index_urls:
             command += ["--extra-index-url", url]
+        if upgrade:
+            command += ["--upgrade"]
         command += ["--"]
         command += requirements
 

--- a/kraken-wrapper/src/kraken/wrapper/venv_manager.py
+++ b/kraken-wrapper/src/kraken/wrapper/venv_manager.py
@@ -146,12 +146,17 @@ class VirtualEnvManager:
     def get_lockfile(self, requirements: RequirementSpec) -> Lockfile:
         return Lockfile(requirements=requirements, pinned={dist.name: dist.version for dist in self._venv.freeze()})
 
-    def install(self, requirements: RequirementSpec, reinstall: bool) -> None:
+    def install(self, requirements: RequirementSpec, reinstall: bool, upgrade: bool) -> None:
         """
         Ensure that the virtual environment managed by this instance conforms to the specified requirements.
 
         The environment may be re-created if it is found to be in an unrecoverable state (e.g. if the interpreter
         version constraint is no longer satisfied or the environment is entirely broken).
+
+        Args:
+            requirements: The specification for the environment.
+            reinstall: Whether to perform a fresh install.
+            upgrade: Whether to upgrade existing packages to their latest (compatible) version.
         """
 
         # Inject credentials into the requirements.
@@ -211,6 +216,7 @@ class VirtualEnvManager:
                 requirements=flatten(req.to_args(self._project_root) for req in requirements.requirements),
                 index_url=requirements.index_url,
                 extra_index_urls=requirements.extra_index_urls,
+                upgrade=upgrade,
             )
         else:
             logger.info("No requirements specified, skipping install step.")


### PR DESCRIPTION
This fixes a regression introduced in a previous version where the `--upgrade` flag would not actually upgrade already installed dependencies. Before this change, the only effect it had was to consider the requirements from the `.kraken.py` instead of `.kraken.lock`.