### PR TITLE
fix: Pass `--python-version` argument to `uv pip install` to ensure the minimum interpreter constraint in the buildscript requirements is respected

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "aa2cba40-ff5c-42b0-a1b8-636f522db101"
 type = "fix"
 description = "`krakenw --upgrade` now passes the `--upgrade` flag to `uv pip install`, as expected"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "e4028844-450c-4c4c-b01c-cabc0b1ffcf8"
+type = "fix"
+description = "Pass `--python-version` argument to `uv pip install` to ensure the minimum interpreter constraint in the buildscript requirements is respected"
+author = "@NiklasRosenstein"

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
 from ._buildscript import BuildscriptMetadata
 from ._generic import NotSet, flatten
 
@@ -248,3 +251,22 @@ class RequirementSpec:
             additional_sys_paths=[x for x in self.pythonpath if x != DEFAULT_BUILD_SUPPORT_FOLDER],
             interpreter_constraint=DEFAULT_INTERPRETER_CONSTRAINT,
         )
+
+    def get_python_min_version(self) -> str | None:
+        """
+        Return the minimum version of Python that must be supported by this RequirementSpec.
+
+        This is not a perfect representation of the `interpreter_constraint`, but it is needed with the method
+        that we use for `uv pip install` nowadays.
+        """
+
+        if self.interpreter_constraint is None:
+            return None
+
+        min_version: str | None = None
+        for spec in SpecifierSet(self.interpreter_constraint):
+            if spec.operator in (">", ">="):
+                if min_version is None or Version(min_version) > Version(spec.version):
+                    min_version = spec.version
+
+        return min_version

--- a/kraken-wrapper/src/kraken/wrapper/uv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/uv_venv.py
@@ -97,6 +97,7 @@ class UvVirtualEnv:
         requirements: Iterable[str],
         index_url: str | None = None,
         extra_index_urls: Sequence[str] = (),
+        python_version: str | None = None,
         upgrade: bool = False,
     ) -> None:
         """
@@ -116,6 +117,8 @@ class UvVirtualEnv:
             command += ["--index-url", index_url]
         for url in extra_index_urls:
             command += ["--extra-index-url", url]
+        if python_version:
+            command += ["--python-version", python_version]
         if upgrade:
             command += ["--upgrade"]
         command += ["--"]

--- a/kraken-wrapper/src/kraken/wrapper/venv_manager.py
+++ b/kraken-wrapper/src/kraken/wrapper/venv_manager.py
@@ -216,6 +216,9 @@ class VirtualEnvManager:
                 requirements=flatten(req.to_args(self._project_root) for req in requirements.requirements),
                 index_url=requirements.index_url,
                 extra_index_urls=requirements.extra_index_urls,
+                # NOTE: If we don't specify a min version, Uv will install only for the current version. We currently
+                #       prefer 3.10 as the minimum if no other is set.
+                python_version=requirements.get_python_min_version() or "3.10",
                 upgrade=upgrade,
             )
         else:


### PR DESCRIPTION
Before this PR, `uv pip install` would be run without the `--python-version` option, making it install the latest package versions compatible with the current Python version, which may not always be the minimum Python version that is permitted by the build script.

The `buildscript(interpreter_constraint)` defaults to `>=3.10`, but when the environment on your machine is getting created with 3.15 for example, you may get `networkx 3.5` which does not install into 3.10.