### PR TITLE
Use Uv's dependency resolution mechanism over `uv pip install`

### DIFF
--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -127,6 +127,8 @@ class UrlRequirement(Requirement):
                 parsed = parsed._replace(path=path)
 
                 # Heuristic for telling whether it's a tag, branch or rev.
+                # The following regex matches Git references that are likely version tags.
+                # Examples include 'v1.0.0', '1.0.0', or paths like 'kraken-build/v0.44.2'.
                 if re.match(r"((.*/v)|v?)\d+.*\.", ref):
                     result["tag"] = ref
                 elif re.match(r"[0-9a-f]{7,}$", ref):

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse, urlunparse
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
@@ -85,6 +85,9 @@ class LocalRequirement(Requirement):
     def to_args(self, base_dir: Path) -> list[str]:
         return [str((base_dir / self.path if base_dir else self.path).absolute())]
 
+    def to_uv_source(self) -> dict[str, Any]:
+        return {"path": self.path, "editable": True}
+
 
 @dataclasses.dataclass(frozen=True)
 class UrlRequirement(Requirement):
@@ -105,6 +108,36 @@ class UrlRequirement(Requirement):
 
     def to_args(self, base_dir: Path) -> list[str]:
         return [str(self)]
+
+    def to_uv_source(self) -> dict[str, Any]:
+        result = {}
+        if (url := self.url).startswith("git+"):
+            parsed = urlparse(self.url)
+            params = parse_qs(parsed.fragment)
+
+            # Strip the Git hints from the URL.
+            parsed = parsed._replace(scheme=parsed.scheme[4:], fragment="")
+
+            if subdirectory := params.get("subdirectory"):
+                result["subdirectory"] = subdirectory[0]
+
+            if "@" in parsed.path:
+                path, ref = parsed.path.partition("@")[::2]
+                parsed = parsed._replace(path=path)
+
+                # Heuristic for telling whether it's a tag, branch or rev.
+                if re.match(r"((.*/v)|v?)\d+.*\.", ref):
+                    result["tag"] = ref
+                elif re.match(r"[0-9a-f]{7,}$", ref):
+                    result["rev"] = ref
+                else:
+                    result["branch"] = ref
+
+            result["git"] = urlunparse(parsed)
+        else:
+            result["url"] = url
+
+        return result
 
 
 @dataclasses.dataclass(frozen=True)

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -3,6 +3,7 @@ import argparse
 import dataclasses
 import hashlib
 import logging
+from os import fspath
 import re
 from collections.abc import Iterable
 from pathlib import Path
@@ -86,7 +87,7 @@ class LocalRequirement(Requirement):
         return [str((base_dir / self.path if base_dir else self.path).absolute())]
 
     def to_uv_source(self) -> dict[str, Any]:
-        return {"path": self.path, "editable": True}
+        return {"path": fspath(self.path), "editable": True}
 
 
 @dataclasses.dataclass(frozen=True)

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -129,7 +129,7 @@ class UrlRequirement(Requirement):
                 # Heuristic for telling whether it's a tag, branch or rev.
                 # The following regex matches Git references that are likely version tags.
                 # Examples include 'v1.0.0', '1.0.0', or paths like 'kraken-build/v0.44.2'.
-                if re.match(r"((.*/v)|v?)\d+.*\.", ref):
+                if re.match(r"((.*/v?)|v?)\d+.*\.", ref):
                     result["tag"] = ref
                 # Match Git commit SHA hashes (7 or more hexadecimal characters).
                 elif re.match(r"[0-9a-f]{7,}$", ref):

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -3,9 +3,9 @@ import argparse
 import dataclasses
 import hashlib
 import logging
-from os import fspath
 import re
 from collections.abc import Iterable
+from os import fspath
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse, urlunparse

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Iterable
 from os import fspath
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 from packaging.specifiers import SpecifierSet
@@ -125,23 +125,38 @@ class UrlRequirement(Requirement):
             if "@" in parsed.path:
                 path, ref = parsed.path.partition("@")[::2]
                 parsed = parsed._replace(path=path)
-
-                # Heuristic for telling whether it's a tag, branch or rev.
-                # The following regex matches Git references that are likely version tags.
-                # Examples include 'v1.0.0', '1.0.0', or paths like 'kraken-build/v0.44.2'.
-                if re.match(r"((.*/v?)|v?)\d+.*\.", ref):
-                    result["tag"] = ref
-                # Match Git commit SHA hashes (7 or more hexadecimal characters).
-                elif re.match(r"[0-9a-f]{7,}$", ref):
-                    result["rev"] = ref
-                else:
-                    result["branch"] = ref
+                result[self._classify_git_ref(ref)] = ref
 
             result["git"] = urlunparse(parsed)
         else:
             result["url"] = url
-
         return result
+
+    @staticmethod
+    def _classify_git_ref(ref: str) -> Literal["rev", "tag", "branch"]:
+        """
+        Classify a Git reference as a tag, branch, or revision.
+        Args:
+            ref (str): The Git reference to classify.
+
+        Examples:
+            >>> UrlRequirement._classify_git_ref("v1.0.0")
+            'tag'
+            >>> UrlRequirement._classify_git_ref("abcdef1")
+            'rev'
+            >>> UrlRequirement._classify_git_ref("main")
+            'branch'
+        """
+
+        # Match Git commit SHA hashes (7 or more hexadecimal characters).
+        if re.match(r"[0-9a-f]{7,}$", ref):
+            return "rev"
+
+        # Match Git references that are likely version tags.
+        if re.match(r"((.*/v?)|v?)\d+.*\.", ref):
+            return "tag"
+
+        return "branch"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -131,6 +131,7 @@ class UrlRequirement(Requirement):
                 # Examples include 'v1.0.0', '1.0.0', or paths like 'kraken-build/v0.44.2'.
                 if re.match(r"((.*/v)|v?)\d+.*\.", ref):
                     result["tag"] = ref
+                # Match Git commit SHA hashes (7 or more hexadecimal characters).
                 elif re.match(r"[0-9a-f]{7,}$", ref):
                     result["rev"] = ref
                 else:

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -84,10 +84,10 @@ class LocalRequirement(Requirement):
         return f"{self.name} @ {self.path}"
 
     def to_args(self, base_dir: Path) -> list[str]:
-        return [str((base_dir / self.path if base_dir else self.path).absolute())]
+        return [fspath((base_dir / self.path).absolute())]
 
-    def to_uv_source(self) -> dict[str, Any]:
-        return {"path": fspath(self.path), "editable": True}
+    def to_uv_source(self, base_dir: Path) -> dict[str, Any]:
+        return {"path": fspath((base_dir / self.path).absolute()), "editable": True}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -110,7 +110,7 @@ class UrlRequirement(Requirement):
     def to_args(self, base_dir: Path) -> list[str]:
         return [str(self)]
 
-    def to_uv_source(self) -> dict[str, Any]:
+    def to_uv_source(self, base_dir: Path) -> dict[str, Any]:
         result = {}
         if (url := self.url).startswith("git+"):
             parsed = urlparse(self.url)

--- a/kraken-build/src/kraken/common/_requirements_test.py
+++ b/kraken-build/src/kraken/common/_requirements_test.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from pytest import raises
 
 from kraken.common import LocalRequirement, PipRequirement, parse_requirement
+from kraken.common._requirements import UrlRequirement
 
 
 def test__parse_requirement__can_handle_various_pip_requirements() -> None:
@@ -18,3 +19,59 @@ def test__parse_requirement__can_handle_local_requirements() -> None:
     assert parse_requirement("kraken-std@.") == LocalRequirement("kraken-std", Path("."))
     assert parse_requirement("abc @ ./abc") == LocalRequirement("abc", Path("./abc"))
     assert parse_requirement("abc@/module/at/abc") == LocalRequirement("abc", Path("/module/at/abc"))
+
+
+def test__parse_requirement__can_handle_url_requirements() -> None:
+    assert parse_requirement(
+        "kraken-build@ git+https://github.com/kraken-build.git@0.44.2#subdirectory=kraken-build"
+    ) == UrlRequirement(
+        "kraken-build",
+        "git+https://github.com/kraken-build.git@0.44.2#subdirectory=kraken-build",
+    )
+
+
+def test__UrlRequirement__to_uv_source() -> None:
+    assert UrlRequirement(
+        "kraken-build",
+        "git+https://github.com/kraken-build.git@master#subdirectory=kraken-build",
+    ).to_uv_source() == {
+        "git": "https://github.com/kraken-build.git",
+        "branch": "master",
+        "subdirectory": "kraken-build",
+    }
+
+    assert UrlRequirement(
+        "kraken-build",
+        "git+https://github.com/kraken-build.git@deadbeef#subdirectory=kraken-build",
+    ).to_uv_source() == {
+        "git": "https://github.com/kraken-build.git",
+        "rev": "deadbeef",
+        "subdirectory": "kraken-build",
+    }
+
+    assert UrlRequirement(
+        "kraken-build",
+        "git+https://github.com/kraken-build.git@deadbeef/imabranch#subdirectory=kraken-build",
+    ).to_uv_source() == {
+        "git": "https://github.com/kraken-build.git",
+        "branch": "deadbeef/imabranch",
+        "subdirectory": "kraken-build",
+    }
+
+    assert UrlRequirement(
+        "kraken-build",
+        "git+https://github.com/kraken-build.git@0.44.2#subdirectory=kraken-build",
+    ).to_uv_source() == {
+        "git": "https://github.com/kraken-build.git",
+        "tag": "0.44.2",
+        "subdirectory": "kraken-build",
+    }
+
+    assert UrlRequirement(
+        "kraken-build",
+        "git+https://github.com/kraken-build.git@kraken-build/v0.44.2#subdirectory=kraken-build",
+    ).to_uv_source() == {
+        "git": "https://github.com/kraken-build.git",
+        "tag": "kraken-build/v0.44.2",
+        "subdirectory": "kraken-build",
+    }

--- a/kraken-build/src/kraken/common/_requirements_test.py
+++ b/kraken-build/src/kraken/common/_requirements_test.py
@@ -34,7 +34,7 @@ def test__UrlRequirement__to_uv_source() -> None:
     assert UrlRequirement(
         "kraken-build",
         "git+https://github.com/kraken-build.git@master#subdirectory=kraken-build",
-    ).to_uv_source() == {
+    ).to_uv_source(Path.cwd()) == {
         "git": "https://github.com/kraken-build.git",
         "branch": "master",
         "subdirectory": "kraken-build",
@@ -43,7 +43,7 @@ def test__UrlRequirement__to_uv_source() -> None:
     assert UrlRequirement(
         "kraken-build",
         "git+https://github.com/kraken-build.git@deadbeef#subdirectory=kraken-build",
-    ).to_uv_source() == {
+    ).to_uv_source(Path.cwd()) == {
         "git": "https://github.com/kraken-build.git",
         "rev": "deadbeef",
         "subdirectory": "kraken-build",
@@ -52,7 +52,7 @@ def test__UrlRequirement__to_uv_source() -> None:
     assert UrlRequirement(
         "kraken-build",
         "git+https://github.com/kraken-build.git@deadbeef/imabranch#subdirectory=kraken-build",
-    ).to_uv_source() == {
+    ).to_uv_source(Path.cwd()) == {
         "git": "https://github.com/kraken-build.git",
         "branch": "deadbeef/imabranch",
         "subdirectory": "kraken-build",
@@ -61,7 +61,7 @@ def test__UrlRequirement__to_uv_source() -> None:
     assert UrlRequirement(
         "kraken-build",
         "git+https://github.com/kraken-build.git@0.44.2#subdirectory=kraken-build",
-    ).to_uv_source() == {
+    ).to_uv_source(Path.cwd()) == {
         "git": "https://github.com/kraken-build.git",
         "tag": "0.44.2",
         "subdirectory": "kraken-build",
@@ -70,7 +70,7 @@ def test__UrlRequirement__to_uv_source() -> None:
     assert UrlRequirement(
         "kraken-build",
         "git+https://github.com/kraken-build.git@kraken-build/v0.44.2#subdirectory=kraken-build",
-    ).to_uv_source() == {
+    ).to_uv_source(Path.cwd()) == {
         "git": "https://github.com/kraken-build.git",
         "tag": "kraken-build/v0.44.2",
         "subdirectory": "kraken-build",

--- a/kraken-wrapper/.changelog/_unreleased.toml
+++ b/kraken-wrapper/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "d1a38ce2-67db-4e7b-bfbf-3f846390d878"
+type = "improvement"
+description = "Use Uv's own dependency resolution mechanism when installing build environments instead of `uv pip`, which cannot properly respect the interpreter constraint"
+author = "@NiklasRosenstein"

--- a/kraken-wrapper/src/kraken/wrapper/uv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/uv_venv.py
@@ -5,11 +5,14 @@ import os
 import subprocess
 from os import fsdecode
 from pathlib import Path
-from typing import Iterable, MutableMapping, NamedTuple, Sequence
+from tempfile import TemporaryDirectory
+from typing import Any, Iterable, MutableMapping, NamedTuple, Sequence
 
+import tomli_w
 from uv.__main__ import find_uv_bin
 
 from kraken.common._fs import safe_rmpath
+from kraken.common._requirements import LocalRequirement, PipRequirement, RequirementSpec, UrlRequirement
 from kraken.common.findpython import get_python_interpreter_version
 from kraken.common.path import is_relative_to
 from kraken.common.sanitize import sanitize_http_basic_auth
@@ -179,3 +182,89 @@ class UvVirtualEnv:
         paths = environ.get("PATH", "").split(os.pathsep)
         paths = [path for path in paths if not is_relative_to(Path(path), self.path)]
         environ["PATH"] = os.pathsep.join(paths)
+
+
+class UvProjectShim:
+    """
+    Helper class that acts like a proper Python project to get Uv to generate a lock file
+    and install into a virtual environment.
+    """
+
+    def __init__(self, project_name: str = "kraken-build-env", version: str = "0.0.0") -> None:
+        self._tempdir = TemporaryDirectory()
+        self.project_name = project_name
+        self.version = version
+
+    def __enter__(self) -> UvProjectShim:
+        self._tempdir.__enter__()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self._tempdir.__exit__(*args)
+
+    @staticmethod
+    def generate_pyproject_toml(project_name: str, version: str, requirements: RequirementSpec) -> dict[str, Any]:
+        payload = {
+            "project": {
+                "name": project_name,
+                "version": version,
+                "dependencies": (dependencies := []),
+                "requires-python": requirements.interpreter_constraint or ">=3.10",
+            },
+            "tool": {
+                "uv": {
+                    "sources": (sources := {}),
+                    "index": (indexes := []),
+                }
+            },
+        }
+
+        for req in requirements.requirements:
+            match req:
+                case PipRequirement():
+                    dependencies.append(str(req))
+                case LocalRequirement() | UrlRequirement():
+                    dependencies.append(req.name)
+                    sources[req.name] = req.to_uv_source()
+                case _:
+                    assert False, f"unexpected req: {req!r}"
+
+        if requirements.index_url:
+            indexes.append({"url": requirements.index_url, "default": True})
+
+        for url in requirements.extra_index_urls:
+            indexes.append({"url": url})
+
+        return payload
+
+    def write_pyproject_toml(self, requirements: RequirementSpec) -> None:
+        payload = self.generate_pyproject_toml(self.project_name, self.version, requirements)
+        self.pyproject_toml().write_text(tomli_w.dumps(payload))
+
+    def sync(self, venv: UvVirtualEnv) -> None:
+        """Run `uv sync` for the project."""
+
+        command = ["uv", "sync", "--project", self._tempdir.name, "--python", str(venv.python_bin)]
+        logger.debug("Installing into build environment with uv: %s", sanitize_http_basic_auth(" ".join(command)))
+        subprocess.check_call(
+            command, cwd=self._tempdir.name, env=os.environ | {"UV_PROJECT_ENVIRONMENT": str(venv.path)}
+        )
+
+    def lock(self, venv: UvVirtualEnv) -> None:
+        """Run `uv lock` for the project."""
+
+        command = ["uv", "lock", "--project", self._tempdir.name, "--python", str(venv.python_bin)]
+        logger.debug("Locking build environment with uv: %s", sanitize_http_basic_auth(" ".join(command)))
+        subprocess.check_call(
+            command, cwd=self._tempdir.name, env=os.environ | {"UV_PROJECT_ENVIRONMENT": str(venv.path)}
+        )
+
+    def pyproject_toml(self) -> Path:
+        """Return the path to the pyproject.toml file."""
+
+        return Path(self._tempdir.name).joinpath("pyproject.toml")
+
+    def lockfile(self) -> Path:
+        """Return the path to the Uv lockfile."""
+
+        return Path(self._tempdir.name).joinpath("uv.lock")

--- a/kraken-wrapper/src/kraken/wrapper/uv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/uv_venv.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
-from os import fsdecode
+from os import fsdecode, fspath
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Iterable, MutableMapping, NamedTuple, Sequence
@@ -244,19 +244,19 @@ class UvProjectShim:
     def sync(self, venv: UvVirtualEnv) -> None:
         """Run `uv sync` for the project."""
 
-        command = ["uv", "sync", "--project", self._tempdir.name, "--python", str(venv.python_bin)]
+        command = ["uv", "sync", "--project", self._tempdir.name, "--python", fspath(venv.python_bin)]
         logger.debug("Installing into build environment with uv: %s", sanitize_http_basic_auth(" ".join(command)))
         subprocess.check_call(
-            command, cwd=self._tempdir.name, env=os.environ | {"UV_PROJECT_ENVIRONMENT": str(venv.path)}
+            command, cwd=self._tempdir.name, env=os.environ | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)}
         )
 
     def lock(self, venv: UvVirtualEnv) -> None:
         """Run `uv lock` for the project."""
 
-        command = ["uv", "lock", "--project", self._tempdir.name, "--python", str(venv.python_bin)]
+        command = ["uv", "lock", "--project", self._tempdir.name, "--python", fspath(venv.python_bin)]
         logger.debug("Locking build environment with uv: %s", sanitize_http_basic_auth(" ".join(command)))
         subprocess.check_call(
-            command, cwd=self._tempdir.name, env=os.environ | {"UV_PROJECT_ENVIRONMENT": str(venv.path)}
+            command, cwd=self._tempdir.name, env=os.environ | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)}
         )
 
     def pyproject_toml(self) -> Path:

--- a/kraken-wrapper/src/kraken/wrapper/uv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/uv_venv.py
@@ -197,15 +197,17 @@ class UvProjectShim:
     """
 
     def __init__(self, project_name: str = "kraken-build-env", version: str = "0.0.0") -> None:
-        self._tempdir = TemporaryDirectory()
+        self._tempdir: TemporaryDirectory[str] | None = None
         self.project_name = project_name
         self.version = version
 
     def __enter__(self) -> UvProjectShim:
+        self._tempdir = TemporaryDirectory()
         self._tempdir.__enter__()
         return self
 
     def __exit__(self, *args: Any) -> None:
+        assert self._tempdir is not None
         self._tempdir.__exit__(*args)
 
     @staticmethod
@@ -265,6 +267,8 @@ class UvProjectShim:
     def sync(self, venv: UvVirtualEnv) -> None:
         """Run `uv sync` for the project."""
 
+        assert self._tempdir is not None, "context not entered"
+
         command = ["uv", "sync", "--project", self._tempdir.name, "--python", fspath(venv.python_bin)]
         logger.debug("Installing into build environment with uv: %s", sanitize_http_basic_auth(" ".join(command)))
         subprocess.check_call(
@@ -276,6 +280,8 @@ class UvProjectShim:
 
     def lock(self, venv: UvVirtualEnv) -> None:
         """Run `uv lock` for the project."""
+
+        assert self._tempdir is not None, "context not entered"
 
         command = ["uv", "lock", "--project", self._tempdir.name, "--python", fspath(venv.python_bin)]
         logger.debug("Locking build environment with uv: %s", sanitize_http_basic_auth(" ".join(command)))
@@ -289,9 +295,11 @@ class UvProjectShim:
     def pyproject_toml(self) -> Path:
         """Return the path to the pyproject.toml file."""
 
+        assert self._tempdir is not None, "context not entered"
         return Path(self._tempdir.name).joinpath("pyproject.toml")
 
     def lockfile(self) -> Path:
         """Return the path to the Uv lockfile."""
 
+        assert self._tempdir is not None, "context not entered"
         return Path(self._tempdir.name).joinpath("uv.lock")

--- a/kraken-wrapper/src/kraken/wrapper/uv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/uv_venv.py
@@ -203,7 +203,22 @@ class UvProjectShim:
         self._tempdir.__exit__(*args)
 
     @staticmethod
-    def generate_pyproject_toml(project_name: str, version: str, requirements: RequirementSpec) -> dict[str, Any]:
+    def generate_pyproject_toml(
+        base_dir: Path,
+        project_name: str,
+        version: str,
+        requirements: RequirementSpec,
+    ) -> dict[str, Any]:
+        """
+        Generates the payload for a `pyproject.toml`.
+
+        Args:
+            base_dir: The base directory where local, relative requirements are considered relative to.
+            project_name: The name to put into the `[project]` section.
+            version: The version to put into the `[project]` section.
+            requirements: The requirements. All fields but the `pythonpath` are taken into account.
+        """
+
         payload = {
             "project": {
                 "name": project_name,
@@ -225,7 +240,7 @@ class UvProjectShim:
                     dependencies.append(str(req))
                 case LocalRequirement() | UrlRequirement():
                     dependencies.append(req.name)
-                    sources[req.name] = req.to_uv_source()
+                    sources[req.name] = req.to_uv_source(base_dir)
                 case _:
                     assert False, f"unexpected req: {req!r}"
 
@@ -237,8 +252,8 @@ class UvProjectShim:
 
         return payload
 
-    def write_pyproject_toml(self, requirements: RequirementSpec) -> None:
-        payload = self.generate_pyproject_toml(self.project_name, self.version, requirements)
+    def write_pyproject_toml(self, base_dir: Path, requirements: RequirementSpec) -> None:
+        payload = self.generate_pyproject_toml(base_dir, self.project_name, self.version, requirements)
         self.pyproject_toml().write_text(tomli_w.dumps(payload))
 
     def sync(self, venv: UvVirtualEnv) -> None:
@@ -249,7 +264,8 @@ class UvProjectShim:
         subprocess.check_call(
             command,
             cwd=self._tempdir.name,
-            env=os.environ | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)},
+            env={k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+            | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)},
         )
 
     def lock(self, venv: UvVirtualEnv) -> None:
@@ -260,7 +276,8 @@ class UvProjectShim:
         subprocess.check_call(
             command,
             cwd=self._tempdir.name,
-            env=os.environ | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)},
+            env={k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+            | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)},
         )
 
     def pyproject_toml(self) -> Path:

--- a/kraken-wrapper/src/kraken/wrapper/uv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/uv_venv.py
@@ -247,7 +247,9 @@ class UvProjectShim:
         command = ["uv", "sync", "--project", self._tempdir.name, "--python", fspath(venv.python_bin)]
         logger.debug("Installing into build environment with uv: %s", sanitize_http_basic_auth(" ".join(command)))
         subprocess.check_call(
-            command, cwd=self._tempdir.name, env=os.environ | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)}
+            command,
+            cwd=self._tempdir.name,
+            env=os.environ | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)},
         )
 
     def lock(self, venv: UvVirtualEnv) -> None:
@@ -256,7 +258,9 @@ class UvProjectShim:
         command = ["uv", "lock", "--project", self._tempdir.name, "--python", fspath(venv.python_bin)]
         logger.debug("Locking build environment with uv: %s", sanitize_http_basic_auth(" ".join(command)))
         subprocess.check_call(
-            command, cwd=self._tempdir.name, env=os.environ | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)}
+            command,
+            cwd=self._tempdir.name,
+            env=os.environ | {"UV_PROJECT_ENVIRONMENT": fspath(venv.path)},
         )
 
     def pyproject_toml(self) -> Path:

--- a/kraken-wrapper/src/kraken/wrapper/uv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/uv_venv.py
@@ -12,7 +12,13 @@ import tomli_w
 from uv.__main__ import find_uv_bin
 
 from kraken.common._fs import safe_rmpath
-from kraken.common._requirements import LocalRequirement, PipRequirement, RequirementSpec, UrlRequirement
+from kraken.common._requirements import (
+    DEFAULT_INTERPRETER_CONSTRAINT,
+    LocalRequirement,
+    PipRequirement,
+    RequirementSpec,
+    UrlRequirement,
+)
 from kraken.common.findpython import get_python_interpreter_version
 from kraken.common.path import is_relative_to
 from kraken.common.sanitize import sanitize_http_basic_auth
@@ -224,7 +230,7 @@ class UvProjectShim:
                 "name": project_name,
                 "version": version,
                 "dependencies": (dependencies := []),
-                "requires-python": requirements.interpreter_constraint or ">=3.10",
+                "requires-python": requirements.interpreter_constraint or DEFAULT_INTERPRETER_CONSTRAINT,
             },
             "tool": {
                 "uv": {

--- a/kraken-wrapper/src/kraken/wrapper/uv_venv.py
+++ b/kraken-wrapper/src/kraken/wrapper/uv_venv.py
@@ -242,7 +242,7 @@ class UvProjectShim:
                     dependencies.append(req.name)
                     sources[req.name] = req.to_uv_source(base_dir)
                 case _:
-                    assert False, f"unexpected req: {req!r}"
+                    assert False, f"unexpected requirement type: {type(req).__name__} - {req!r}"
 
         if requirements.index_url:
             indexes.append({"url": requirements.index_url, "default": True})

--- a/kraken-wrapper/src/kraken/wrapper/venv_manager.py
+++ b/kraken-wrapper/src/kraken/wrapper/venv_manager.py
@@ -213,9 +213,9 @@ class VirtualEnvManager:
         if requirements.requirements:
             # We want to leverage Uv's dependency resolution mechanism, which we can't mimic with `uv pip`.
             # So instead, we generate a fake project with the requirements.
-            shim = UvProjectShim()
-            shim.write_pyproject_toml(self._project_root, requirements)
-            shim.sync(self._venv)
+            with UvProjectShim() as shim:
+                shim.write_pyproject_toml(self._project_root, requirements)
+                shim.sync(self._venv)
         else:
             logger.info("No requirements specified, skipping install step.")
 

--- a/kraken-wrapper/src/kraken/wrapper/venv_manager.py
+++ b/kraken-wrapper/src/kraken/wrapper/venv_manager.py
@@ -23,9 +23,8 @@ from kraken.common import (
     not_none,
     safe_rmpath,
 )
-from kraken.common._generic import flatten
 from kraken.std.util.url import inject_url_credentials
-from kraken.wrapper.uv_venv import UvVirtualEnv
+from kraken.wrapper.uv_venv import UvProjectShim, UvVirtualEnv
 
 from ._config import AuthModel
 
@@ -212,15 +211,11 @@ class VirtualEnvManager:
             self._venv.create(python=Path(original_python))
 
         if requirements.requirements:
-            self._venv.install(
-                requirements=flatten(req.to_args(self._project_root) for req in requirements.requirements),
-                index_url=requirements.index_url,
-                extra_index_urls=requirements.extra_index_urls,
-                # NOTE: If we don't specify a min version, Uv will install only for the current version. We currently
-                #       prefer 3.10 as the minimum if no other is set.
-                python_version=requirements.get_python_min_version() or "3.10",
-                upgrade=upgrade,
-            )
+            # We want to leverage Uv's dependency resolution mechanism, which we can't mimic with `uv pip`.
+            # So instead, we generate a fake project with the requirements.
+            shim = UvProjectShim()
+            shim.write_pyproject_toml(requirements)
+            shim.sync(self._venv)
         else:
             logger.info("No requirements specified, skipping install step.")
 

--- a/kraken-wrapper/src/kraken/wrapper/venv_manager.py
+++ b/kraken-wrapper/src/kraken/wrapper/venv_manager.py
@@ -214,7 +214,7 @@ class VirtualEnvManager:
             # We want to leverage Uv's dependency resolution mechanism, which we can't mimic with `uv pip`.
             # So instead, we generate a fake project with the requirements.
             shim = UvProjectShim()
-            shim.write_pyproject_toml(requirements)
+            shim.write_pyproject_toml(self._project_root, requirements)
             shim.sync(self._venv)
         else:
             logger.info("No requirements specified, skipping install step.")

--- a/kraken-wrapper/tests/iss-263/test_main.py
+++ b/kraken-wrapper/tests/iss-263/test_main.py
@@ -30,13 +30,19 @@ def chdir(path: Path) -> Iterator[None]:
 
 
 def test__issue_263__local_dependency_is_considered_relative_to_project_root() -> None:
+    """
+    This test validates that a dependency from a relative path can be installed when specified in `buildscript()`
+    and that this dependency is considered relative to the project root (where the `buildscript()` call is made),
+    rather than the current working directory.
+    """
+
     with TemporaryDirectory() as tmp:
         shutil.copytree(DEPENDENCY, Path(tmp) / DEPENDENCY.name)
         shutil.copytree(EXAMPLE_PROJECT, Path(tmp) / EXAMPLE_PROJECT.name)
 
         with chdir(Path(tmp) / EXAMPLE_PROJECT.name / "subproject"):
             with pytest.raises(SystemExit) as excinfo:
-                main(["--use", "UV", "run", "-s"])
+                main(["run", "-s"])
             assert excinfo.value.code == 0
 
         # We expect that the example_project/subproject/.kraken.py creates a file.


### PR DESCRIPTION
This gives us a more stable `.kraken.lock` file that works across a range of Python versions (as specified with the `interpreter_constraint` that defaults to `>=3.10`).

The next step would be to change the `.kraken.lock` file format to just be a `uv.lock` file.