### PR TITLE
Ignore error code 403 in additional indexes

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "10af1349-1542-4eb8-9680-f25863c57a25"
+type = "fix"
+description = "Ignore error code 403 in additional indexes"
+author = "uluc.sengil@helsing.ai"

--- a/kraken-build/src/kraken/std/python/buildsystem/uv.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/uv.py
@@ -94,12 +94,13 @@ class UvIndexes:
 
     def to_config(self) -> list[dict[str, Any]]:
         """Inject UV configuration for indexes into a configuration."""
-        entries: list[dict[str, str | bool]] = []
+        entries: list[dict[str, str | bool | list[int]]] = []
         for index in self.indexes:
             entry: dict[str, Any] = {}
             if index.name is not None and index.name != "":
                 entry["name"] = index.name
             entry["url"] = index.url
+            entry["ignore-error-codes"] = [403]
             if index.default:
                 entry["default"] = True
             if index.explicit:

--- a/kraken-build/src/kraken/std/python/buildsystem/uv_test.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/uv_test.py
@@ -24,11 +24,13 @@ extra-index-url = [
 [[tool.uv.index]]
 name = "foo"
 url = "https://example.com/foo/simple/"
+ignore-error-codes = [403]
 
 [[tool.uv.index]]
 name = "bar"
 url = "https://example.com/bar/simple/"
 explicit = true
+ignore-error-codes = [403]
 """
 
 
@@ -152,9 +154,9 @@ def test__UvPyprojectHandler__set_package_indexes() -> None:
         ]
     )
     assert handler.raw["tool"]["uv"]["index"] == [
-        {"name": "b", "url": "https://example.com/b", "default": True},
-        {"name": "a", "url": "https://example.com/a"},
-        {"name": "c", "url": "https://example.com/c", "explicit": True},
+        {"name": "b", "url": "https://example.com/b", "default": True, "ignore-error-codes": [403]},
+        {"name": "a", "url": "https://example.com/a", "ignore-error-codes": [403]},
+        {"name": "c", "url": "https://example.com/c", "explicit": True, "ignore-error-codes": [403]},
     ]
     assert handler.raw["tool"]["uv"].get("index-url", None) is None
     assert handler.raw["tool"]["uv"].get("extra-index-url", None) is None
@@ -173,10 +175,10 @@ def test__UvPyprojectHandler__update_packages() -> None:
     assert "index-url" not in handler.raw["tool"]["uv"]
     assert "extra-index-url" not in handler.raw["tool"]["uv"]
     assert handler.raw["tool"]["uv"]["index"] == [
-        {"url": "https://example.com/simple/", "default": True},
-        {"url": "https://example.com/foo/simple/", "name": "foo"},
-        {"url": "https://example.org/simple/"},
-        {"url": "https://example.com/bar/simple/", "name": "bar", "explicit": True},
+        {"url": "https://example.com/simple/", "default": True, "ignore-error-codes": [403]},
+        {"url": "https://example.com/foo/simple/", "name": "foo", "ignore-error-codes": [403]},
+        {"url": "https://example.org/simple/", "ignore-error-codes": [403]},
+        {"url": "https://example.com/bar/simple/", "name": "bar", "explicit": True, "ignore-error-codes": [403]},
     ]
 
 


### PR DESCRIPTION
Whenever we use multiple indexes with authentication, `uv` might try to search non-existent packages in the additional indexes.

This leads to error codes like
```
➜ curl https://private-index.com/simple/hatchling -L
{
  "errors" : [ {
    "status" : 403,
    "message" : "{\"error\":\"Forbidden\",\"reason\":\"User has no permissions to resolve packages.\"}"
  } ]
}%  
```

This will completely prevent packages from building if a deterministic build-system selection is chosen; so some users opt to using nondeterministic methods like `index-strategy = "unsafe-first-match"`.

Ignoring 403's on extra indexes will allow us to fully search all the indexes as per uv's documentation: https://docs.astral.sh/uv/concepts/indexes/#ignoring-error-codes-when-searching-across-indexes