### PR TITLE
fix: `krakenw` now detects broken build environment when `python -V` fails

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -16,3 +16,10 @@ author = "@NiklasRosenstein"
 issues = [
     "https://github.com/kraken-build/kraken/issues/400",
 ]
+
+[[entries]]
+id = "3d3f462c-c28d-41ae-acbf-667ebf78cbca"
+type = "fix"
+description = "`krakenw` now detects broken build environment when `python -V` fails"
+author = "@NiklasRosenstein"
+component = "kraken-wrapper"

--- a/kraken-wrapper/src/kraken/wrapper/main.py
+++ b/kraken-wrapper/src/kraken/wrapper/main.py
@@ -262,59 +262,28 @@ def _ensure_installed(
     reinstall: bool,
     upgrade: bool,
 ) -> None:
-    exists = manager.exists()
-    install = reinstall or upgrade or not exists
-
-    operation: str
-    reason: str | None = None
-
-    if not exists:
-        operation = "Initializing"
-    elif upgrade:
-        operation = "Upgrading"
-    elif reinstall:
-        operation = "Reinstalling"
-    else:
-        operation = "Reusing"
-
-    if not install and exists:
+    if manager.exists():
         metadata = manager.get_metadata()
         if project.lockfile and metadata.requirements_hash != project.lockfile.to_pinned_requirement_spec().to_hash(
             metadata.hash_algorithm
         ):
-            install = True
-            operation = "Re-initializing"
-            reason = "outdated compared to lockfile"
+            logger.info("The build environment is outdated compared to the lockfile.")
         if not project.lockfile and metadata.requirements_hash != project.requirements.to_hash(metadata.hash_algorithm):
-            install = True
-            operation = "Re-initializing"
-            reason = "outdated compared to requirements"
+            logger.info("The build environment is outdated compared to the buildscript requirements.")
 
-    if install:
-        if not project.lockfile or upgrade:
-            source_name = "requirements"
-            source = project.requirements
-            source_file = project.requirements_path
-        else:
-            source_name = "lock file"
-            source = project.lockfile.to_pinned_requirement_spec()
-            source_file = project.lockfile_path
-
-        logger.info(
-            "%s build environment from %s (%s)%s.",
-            operation,
-            source_name,
-            os.path.relpath(source_file),
-            f" ({reason})" if reason else "",
+    if not project.lockfile or upgrade:
+        source = project.requirements
+        logger.debug(
+            'Build environment sourced from project\'s buildscript requirements (path="%s")', project.requirements_path
         )
-
-        tstart = time.perf_counter()
-        manager.install(source, reinstall, upgrade)
-        duration = time.perf_counter() - tstart
-        logger.info("Operation complete after %.3fs.", duration)
-
     else:
-        logger.info("%s build environment", operation)
+        source = project.lockfile.to_pinned_requirement_spec()
+        logger.debug('Build environment sourced from project\'s lockfile (path="%s")', project.lockfile_path)
+
+    tstart = time.perf_counter()
+    manager.install(source, reinstall, upgrade)
+    duration = time.perf_counter() - tstart
+    logger.info("Operation complete after %.3fs.", duration)
 
 
 class Project(NamedTuple):

--- a/kraken-wrapper/src/kraken/wrapper/venv_manager.py
+++ b/kraken-wrapper/src/kraken/wrapper/venv_manager.py
@@ -136,14 +136,7 @@ class VirtualEnvManager:
     def exists(self) -> bool:
         if self._metadata_store.get() is None:
             return False  # If we don't have metadata, we assume the environment does not exist.
-        if self._venv.exists():
-            if self._venv.try_version() is not None:
-                return True
-            logger.warning(
-                'Could not determine version of Python interpreter in virtual env (path="%s"), maybe it broke?',
-                self._venv.path,
-            )
-        return False
+        return self._venv.exists()
 
     def remove(self) -> None:
         self._venv.remove()

--- a/kraken-wrapper/src/kraken/wrapper/venv_manager.py
+++ b/kraken-wrapper/src/kraken/wrapper/venv_manager.py
@@ -136,7 +136,14 @@ class VirtualEnvManager:
     def exists(self) -> bool:
         if self._metadata_store.get() is None:
             return False  # If we don't have metadata, we assume the environment does not exist.
-        return self._venv.exists()
+        if self._venv.exists():
+            if self._venv.try_version() is not None:
+                return True
+            logger.warning(
+                'Could not determine version of Python interpreter in virtual env (path="%s"), maybe it broke?',
+                self._venv.path,
+            )
+        return False
 
     def remove(self) -> None:
         self._venv.remove()
@@ -184,6 +191,11 @@ class VirtualEnvManager:
         if self._venv.exists() and not self._venv.is_success_marker_set():
             logger.warning("Your virtual build environment appears to be corrupt. It will be recreated. This happens")
             logger.warning("by pressing Ctrl+C during its installation, or if you've recently upgraded kraken-wrapper.")
+            safe_rmpath(self._path)
+        elif self._venv.exists() and not self._venv.try_version():
+            logger.warning("Your virtual build environment appears to be corrupt. It will be recreated. This could")
+            logger.warning("have happened by upgrading the Python version on your system that the build environment")
+            logger.warning("was created with prior.")
             safe_rmpath(self._path)
 
         if reinstall and self._venv.exists():


### PR DESCRIPTION
Python virtual envs break when you remove the Python installation that was used to create the environment.

This seems kind of obvious, but it includes cases where you upgrade your system Python version causing it to live at another path (e.g. `/opt/homebrew/Cellar/python@3.13/3.13.7/bin/python3` and `/opt/homebrew/Cellar/python@3.14/3.14.0/bin/python3`). The Python version is encoded in most kinds of ways Python is installed, especially because the virtual environment's symlinks point to the real path of the Python interpreter that was used to create it and not an intermediate symlink (as that could be updated to point to a newer version of Python, breaking your virtual env in another way).

Recently it's caused issued when we published a new version of the [kraken-base-image](https://github.com/kraken-build/kraken-base-image) where we only pin the minor version of Python, and Uv installs the latest of that minor branch. Our internal CI caches the virtual environment, thus when CI runs with a newer version of the base image with slightly different Python versions, the virtual environments are broken and error instead of being discarded and re-initialized (as is now done with this PR).

The krakenw entrypoint also had a bit of duplicate logic for determining whether a build environment is to be re-used or needs some additional actions (such as calling `uv sync` once more). The environment manager's `install()` method is now called always and it could make the decision to not invoke `uv` if everything seems up-to-date, but since `uv` is so fast I haven't bothered to do that yet.
