### PR TITLE
Change default Python interpreter constraint from `>=3.10` to `>=3.10,<3.15` to avoid picking up 3.15 before we could test it

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -39,6 +39,6 @@ author = "@NiklasRosenstein"
 [[entries]]
 id = "69acc98a-ccd9-44fc-b3b7-38ce525d5688"
 type = "improvement"
-description = "Change default Python interpreter constraint from `>=3.10` to `>=3.10,<3.14` to avoid picking up 3.15 before we could test it"
+description = "Change default Python interpreter constraint from `>=3.10` to `>=3.10,<3.15` to avoid picking up 3.15 before we could test it"
 author = "@NiklasRosenstein"
 component = "kraken-wrapper"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -35,3 +35,10 @@ id = "ff2668cc-97a8-4398-9e4d-e3a5e1c55ef2"
 type = "improvement"
 description = "Print mitmweb logs if it fails to start when a CI environment is detected."
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "69acc98a-ccd9-44fc-b3b7-38ce525d5688"
+type = "improvement"
+description = "Change default Python interpreter constraint from `>=3.10` to `>=3.10,<3.14` to avoid picking up 3.15 before we could test it"
+author = "@NiklasRosenstein"
+component = "kraken-wrapper"

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -18,7 +18,7 @@ from ._generic import NotSet, flatten
 
 logger = logging.getLogger(__name__)
 DEFAULT_BUILD_SUPPORT_FOLDER = "build-support"
-DEFAULT_INTERPRETER_CONSTRAINT = ">=3.10,<3.14"
+DEFAULT_INTERPRETER_CONSTRAINT = ">=3.10,<3.15"
 
 
 def parse_requirement(value: str) -> "PipRequirement | LocalRequirement | UrlRequirement":

--- a/kraken-build/src/kraken/common/_requirements.py
+++ b/kraken-build/src/kraken/common/_requirements.py
@@ -18,7 +18,7 @@ from ._generic import NotSet, flatten
 
 logger = logging.getLogger(__name__)
 DEFAULT_BUILD_SUPPORT_FOLDER = "build-support"
-DEFAULT_INTERPRETER_CONSTRAINT = ">=3.10"
+DEFAULT_INTERPRETER_CONSTRAINT = ">=3.10,<3.14"
 
 
 def parse_requirement(value: str) -> "PipRequirement | LocalRequirement | UrlRequirement":


### PR DESCRIPTION
While upper bounds on `Requires-Python` turn out to be discouraged widely (see e.g. https://discuss.python.org/t/requires-python-upper-limits/12663/13 and https://docs.astral.sh/uv/reference/internals/resolver/#requires-python), we should still enforce an upper limit on the known range of working Python versions by default when letting `krakenw` create Python virtual environments.

This is to avoid that the introduction of Python 3.15, in case it is incompatible with Kraken, to start breaking builds in CI or locally because `krakenw` will pick the latest  available Python version that matches the interpreter constraint specified. The situation here is different from `Requires-Python` because the constraint can be set in each project by passing the `interpreter_constraint` argument to the `kraken.common.buildscript()` function. We just need to have a sane default.

Note that there is still a bit of a disconnect that could cause issues down the line: The default interpreter constraint here is set in `krakenw`, but that does not guarantee the version of `kraken-build` that will be installed is compatible with that set of Python versions because the version of `krakenw` is likely to diverge. If the gap is large (e.g. 3.15 is released and a latest version of `krakenw` is used that uses `DEFAULT_INTERPRETER_CONSTRAINT = ">=3.10,<3.16"`, but the project that is being built with Kraken is still on an old version of `kraken-build` _and_ the project is getting re-locked _and_ the project does not specify it's own `interpreter_constraint`, `>=3.10,<3.16` will be used as the new constraint and there is a chance it will fail due to 3.15 being used by `krakenw` despite the selected version of `kraken-build` not supporting 3.15).

