### PR TITLE
fix: Upgrade PDM to 2.26.1 which constrains Hishel to <1.0.0

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "92764a7f-617d-46e3-8898-8ffeeff41f94"
+type = "fix"
+description = "Bump PDM to 2.26.1 to fix build errors due to Hishel's refactoring"
+author = "matthieu.antoine@helsing.ai"

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 "pipx:kraken-wrapper" = "0.49.0"
 "pipx:mksync" = "0.1.6"
-"pipx:pdm" = "2.26.0"
+"pipx:pdm" = "2.26.1"
 "pipx:poetry" = "2.2.1"
 "pipx:slap-cli" = "1.15.0"
 typos = "1.38.1"


### PR DESCRIPTION
This will resolve:

```
STATUS: Creating virtualenv using virtualenv...
STATUS: Downloading cpython@3.9.24
ERROR: Failed to install Python cpython@3.9.24: No module named 'hishel._serializers'
[VirtualenvCreateError]: Can't resolve python interpreter
Traceback (most recent call last):
  File "/builds/devx/kraken-hs/.venv/lib/python3.10/site-packages/kraken/core/system/executor/default.py", line 32, in _call
    status = func()
  File "/builds/devx/kraken-hs/.venv/lib/python3.10/site-packages/kraken/std/python/tasks/install_task.py", line 60, in execute
    managed_environment.install(python_settings(self.project))
  File "/builds/devx/kraken-hs/.venv/lib/python3.10/site-packages/kraken/std/python/buildsystem/pdm.py", line 268, in install
    self._get_pdm_environment_path(create=True)
  File "/builds/devx/kraken-hs/.venv/lib/python3.10/site-packages/kraken/std/python/buildsystem/pdm.py", line 238, in _get_pdm_environment_path
    sp.check_call(create_command, cwd=self.project_directory)
  File "/root/.local/share/uv/python/cpython-3.10.19-linux-x86_64-gnu/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['pdm', 'venv', 'create']' returned non-zero exit status 1.
```

See: 
* https://github.com/pdm-project/pdm/issues/3657
* https://github.com/pdm-project/pdm/releases/tag/2.26.1