### PR TITLE
Replace outdated reference to PEX in docstring

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "92764a7f-617d-46e3-8898-8ffeeff41f94"
 type = "fix"
 description = "Bump PDM to 2.26.1 to fix build errors due to Hishel's refactoring"
 author = "matthieu.antoine@helsing.ai"
+
+[[entries]]
+id = "f809b28c-cbc7-4ff6-8165-66111c517715"
+type = "docs"
+description = "Replace outdated reference to PEX in docstring"
+author = "scott@stevenson.io"

--- a/kraken-build/src/kraken/std/python/tasks/mypy_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/mypy_task.py
@@ -97,7 +97,7 @@ def mypy(
     version_spec: str | None = None,
 ) -> MypyTask:
     """
-    :param version_spec: If specified, the Mypy tool will be installed as a PEX and does not need to be installed
+    :param version_spec: If specified, the Mypy tool will be run via `uv tool run` and does not need to be installed
         into the Python project's virtual env.
     """
 


### PR DESCRIPTION
When `version_spec` is specified in the Mypy task, Mypy is now run with `uv tool run` and not installed as a PEX.