### PR TITLE
Fix publish task failing with "Property is finalized" error

### DIFF
--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "375cdbe9-468e-46b4-ba58-bbb8b852ed4f"
+type = "fix"
+description = "Fixed Python publish task failing with \"Property is finalized\" error when `skip_existing=True`"
+author = "John-P@users.noreply.github.com"

--- a/kraken-build/src/kraken/std/python/tasks/publish_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/publish_task.py
@@ -24,7 +24,7 @@ class PublishTask(Task):
     index_upload_url: Property[str]
     index_index_url: Property[str]
     index_credentials: Property[tuple[str, str] | None] = Property.default(None)
-    distributions: Property[list[Path]]
+    distributions: Property[list[Path]] = Property.output()
     skip_existing: Property[bool] = Property.default(False)
     interactive: Property[bool | None] = Property.default(None)
     dependencies: list[Task]


### PR DESCRIPTION
The `PublishTask` was failing with:

```text
RuntimeError: Property(PublishTask(...).distributions) is finalized
```

This occurred when `skip_existing=True` because the code attempted to modify the `distributions` property using `.set()` in `prepare()`, but non-output properties are finalized before `prepare()` runs.

## Solution

Marked the `distributions` property as an output property using `Property.output()`. Output properties can be modified after finalization, allowing the `skip_existing` logic in `prepare()` to filter the list using `.set()`.

## Changes

- Changed `distributions: Property[list[Path]]` to `distributions: Property[list[Path]] = Property.output()`
- This allows the property to be modified in `prepare()` when filtering out files that already exist on the package index
