### PR TITLE
Fix Python Publish Index Check

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -15,3 +15,9 @@ id = "4bb64abf-06bd-43bc-8162-e264604f5e9a"
 type = "improvement"
 description = "Add python.ty to type check with Ty"
 author = "thomas.pellissier-tanon@helsing.ai"
+
+[[entries]]
+id = "d43aec5f-48b0-4946-9ab1-6739a8584acf"
+type = "fix"
+description = "Fix PyPI index check"
+author = "John-P@users.noreply.github.com"

--- a/kraken-build/src/kraken/std/python/tasks/publish_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/publish_task.py
@@ -150,7 +150,7 @@ def _get_existing_files_from_index(
 
         content_type = response.headers.get("Content-Type", "")
         logger.debug(f"PyPI server content type: {content_type}")
-        if "application/vnd.pypi.simple.v1+json" in content_type:
+        if "application/json" in content_type or "application/vnd.pypi.simple.v1+json" in content_type:
             data = response.json()
             return {file_info["filename"] for file_info in data.get("files", [])}
         elif "text/html" in content_type or "application/vnd.pypi.simple.v1+html" in content_type:

--- a/kraken-build/src/kraken/std/python/tasks/publish_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/publish_task.py
@@ -131,7 +131,7 @@ def _get_existing_files_from_index(
 
         if response.status_code == 404:
             # Package not found, so no files exist.
-            logger.debug(f"Project {project_name} (nromalized to {normalized_name}) not found.")
+            logger.debug(f"Project {project_name} (normalized to {normalized_name}) not found.")
             return set()
 
         response.raise_for_status()

--- a/kraken-build/src/kraken/std/python/tasks/publish_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/publish_task.py
@@ -121,7 +121,9 @@ def _get_existing_files_from_index(
     # PEP 503: Names should be normalized.
     # See https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
     normalized_name = canonicalize_name(project_name)
-    url = urllib.parse.urljoin(index_url, f"/{normalized_name}/")
+    logger.debug(f"Index URL: {index_url}")
+    url = urllib.parse.urljoin(f"{index_url}/", normalized_name)
+    logger.debug(f"Normalised package index URL: {url}")
     # For valid Content-Types,
     # see https://packaging.python.org/en/latest/specifications/simple-repository-api/#content-types
     headers = {

--- a/kraken-build/src/kraken/std/python/tasks/publish_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/publish_task.py
@@ -124,7 +124,16 @@ def _get_existing_files_from_index(
     url = urllib.parse.urljoin(index_url, f"/{normalized_name}/")
     # For valid Content-Types,
     # see https://packaging.python.org/en/latest/specifications/simple-repository-api/#content-types
-    headers = {"Accept": "application/vnd.pypi.simple.v1+json"}
+    headers = {
+        "Accept": ",".join(
+            (
+                "application/vnd.pypi.simple.v1+json",
+                "application/vnd.pypi.simple.v1+html",
+                "application/json",
+                "text/html",
+            )
+        )
+    }
 
     try:
         response = httpx.get(url, auth=credentials, headers=headers, follow_redirects=True)

--- a/kraken-build/src/kraken/std/python/tasks/publish_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/publish_task.py
@@ -122,7 +122,7 @@ def _get_existing_files_from_index(
     # See https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
     normalized_name = canonicalize_name(project_name)
     logger.debug(f"Index URL: {index_url}")
-    url = urllib.parse.urljoin(f"{index_url}/", normalized_name)
+    url = urllib.parse.urljoin(f"{index_url}/", f"{normalized_name}/")
     logger.debug(f"Normalised package index URL: {url}")
     # For valid Content-Types,
     # see https://packaging.python.org/en/latest/specifications/simple-repository-api/#content-types

--- a/kraken-build/src/kraken/std/python/tasks/publish_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/publish_task.py
@@ -149,6 +149,7 @@ def _get_existing_files_from_index(
             response.raise_for_status()
 
         content_type = response.headers.get("Content-Type", "")
+        logger.debug(f"PyPI server content type: {content_type}")
         if "application/vnd.pypi.simple.v1+json" in content_type:
             data = response.json()
             return {file_info["filename"] for file_info in data.get("files", [])}

--- a/kraken-build/src/kraken/std/python/tasks/publish_task.py
+++ b/kraken-build/src/kraken/std/python/tasks/publish_task.py
@@ -145,7 +145,8 @@ def _get_existing_files_from_index(
             logger.debug(f"Project {project_name} (normalized to {normalized_name}) not found.")
             return set()
 
-        response.raise_for_status()
+        if response.status_code != 406:
+            response.raise_for_status()
 
         content_type = response.headers.get("Content-Type", "")
         if "application/vnd.pypi.simple.v1+json" in content_type:

--- a/kraken-build/tests/kraken_std/integration/python/test_python.py
+++ b/kraken-build/tests/kraken_std/integration/python/test_python.py
@@ -406,6 +406,7 @@ def test__python_publish_skip_existing(
     "response_type, content_type",
     [
         ("html", "text/html"),  # Alias for application/vnd.pypi.simple.v1+html
+        ("json", "application/json"),  # Alias for application/vnd.pypi.simple.v1+json
         ("html", "application/vnd.pypi.simple.v1+html"),
         ("json", "application/vnd.pypi.simple.v1+json"),
     ],

--- a/kraken-build/tests/kraken_std/integration/python/test_python.py
+++ b/kraken-build/tests/kraken_std/integration/python/test_python.py
@@ -362,6 +362,7 @@ def test__python_publish_skip_existing(
         package_index="local",
         distributions=list(distributions),
         project=kraken_project,
+        skip_existing=True,  # Should not exist yet, but allow anyway
     )
     publish_graph = kraken_ctx.execute([publish_task])
     publish_status = publish_graph.get_status(publish_task)

--- a/kraken-build/tests/kraken_std/integration/python/test_python.py
+++ b/kraken-build/tests/kraken_std/integration/python/test_python.py
@@ -366,7 +366,7 @@ def test__python_publish_skip_existing(
     )
     publish_graph = kraken_ctx.execute([publish_task])
     publish_status = publish_graph.get_status(publish_task)
-    assert publish_status is not None and publish_status.is_succeeded()
+    assert publish_status is not None and (publish_status.is_succeeded() or publish_status.is_skipped())
 
     # Case 1: Try to publish again with skip_existing=True. The task should be skipped.
     publish_task_skip = python.publish(


### PR DESCRIPTION
Fixes several bugs in checking the python index before publishing:

1. Fix typo in debug log.
2. Add more debug logs.
3. Expand client acceptable content types.
4. Do not immediately raise error on 406 to allow negotiation.
5. Fix URL join for package index.
6. Fix allowing `test__python_publish_skip_existing` to run after test__python_project_install_lint_and_publish`. It was failing because the package already existed. This is what ``test__python_publish_skip_existing` needs in setup anyway so simply allowed the case for already existing from change of test order (idempotent setup now).