### PR TITLE
Remove default argument that triggers deprecation warning

### DIFF
--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "375cdbe9-468e-46b4-ba58-bbb8b852ed4f"
 type = "fix"
 description = "Fixed Python publish task failing with \"Property is finalized\" error when `skip_existing=True`"
 author = "John-P@users.noreply.github.com"
+
+[[entries]]
+id = "a1ce3786-5ead-4bf0-8765-ac2f15e9d0e6"
+type = "fix"
+description = "Remove default argument that caused deprecation warning to always be triggered"
+author = "scott@stevenson.io"

--- a/kraken-build/src/kraken/core/cli/option_sets.py
+++ b/kraken-build/src/kraken/core/cli/option_sets.py
@@ -51,7 +51,6 @@ class BuildOptions:
                 "--state-name",
                 metavar="NAME",
                 help="deprecated since 0.45.0. specify a name for the generated state file; if not specified, a short random ID is used",
-                default=str(uuid.uuid4())[:7],
             )
             group.add_argument(
                 "--state-dir",


### PR DESCRIPTION
The deprecated `--state-name` argument was being defined with a default value, derived from a UUID, which caused the `collect` method to always detect the presence of this deprecated argument and log the warning "the --state-name options are deprecated since kraken v0.45.0".