### PR TITLE
Respect PYTHON environment variable for interpreter selection

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,10 @@ id = "a3e95db6-e1f8-4e58-897c-1f73728af61f"
 type = "feature"
 description = "Add support for ty config file"
 author = "scott@stevenson.io"
+
+[[entries]]
+id = "01baa6f3-a13c-4579-95fb-28bd334e6df2"
+type = "improvement"
+description = "Add support for `PYTHON` environment variable in `krakenw`"
+author = "@NiklasRosenstein"
+component = "kraken-wrapper"

--- a/kraken-build/src/kraken/common/findpython.py
+++ b/kraken-build/src/kraken/common/findpython.py
@@ -106,6 +106,13 @@ def _get_candidates(
 ) -> Iterator[InterpreterCandidate]:
     """Internal. Implementation of `get_candidates()` without Pyenv shim detection."""
 
+    # If the PYTHON environment variable is set, yield it as the highest-priority candidate.
+    python_env = os.environ.get("PYTHON")
+    if python_env:
+        python_path = Path(python_env)
+        if python_path.is_file() and os.access(python_path, os.X_OK):
+            yield {"path": str(python_path)}
+
     if path_list is None:
         path_list = os.environ["PATH"].split(os.pathsep)
 

--- a/kraken-wrapper/src/kraken/wrapper/venv_manager.py
+++ b/kraken-wrapper/src/kraken/wrapper/venv_manager.py
@@ -206,6 +206,12 @@ class VirtualEnvManager:
                 logger.debug("Using Python interpreter constraint: %s", requirements.interpreter_constraint)
                 original_python = find_python_interpreter(requirements.interpreter_constraint)
                 logger.debug("Using Python interpreter at %s", original_python)
+            elif python_env := os.environ.get("PYTHON"):
+                logger.info(
+                    "No interpreter constraint specified, using PYTHON environment variable (%s)",
+                    python_env,
+                )
+                original_python = python_env
             else:
                 logger.info(
                     "No interpreter constraint specified, using current Python interpreter (%s)",


### PR DESCRIPTION
## Summary

- When `PYTHON` is set, use it as the highest-priority interpreter candidate in `findpython` and as the fallback in `venv_manager`
- Fixes the case where a PATH-provided Python (e.g. 3.14 via mise) is picked over the user's intended version, causing `pkg_resources` import failures with older kraken packages

## Test plan

- [ ] Set `PYTHON=/path/to/python3.10 krakenw fmt` and verify 3.10 is used
- [ ] Unset `PYTHON` and verify existing behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)