### PR TITLE
Sort Python interpreter candidates for deterministic discovery order

### DIFF
--- a/kraken-build/.changelog/_unreleased.toml
+++ b/kraken-build/.changelog/_unreleased.toml
@@ -9,3 +9,9 @@ id = "a1ce3786-5ead-4bf0-8765-ac2f15e9d0e6"
 type = "fix"
 description = "Remove default argument that caused deprecation warning to always be triggered"
 author = "scott@stevenson.io"
+
+[[entries]]
+id = "5869aeae-b5a2-44c3-9a0c-d1389272da8a"
+type = "fix"
+description = "Make Python version resolution deterministic"
+author = "matthieu@matthieu-antoine.me"

--- a/kraken-build/src/kraken/common/findpython.py
+++ b/kraken-build/src/kraken/common/findpython.py
@@ -116,7 +116,7 @@ def _get_candidates(
     if path_list is None:
         path_list = os.environ["PATH"].split(os.pathsep)
 
-    commands: set[Path] = set()
+    commands_set: set[Path] = set()
     for path in map(Path, path_list):
         if not path.is_dir():
             continue
@@ -129,7 +129,13 @@ def _get_candidates(
             except PermissionError:
                 continue
             else:
-                commands.add(item)
+                commands_set.add(item)
+
+    # Sort for deterministic iteration order. Without this, set iteration
+    # order depends on PYTHONHASHSEED, which is randomised per-process,
+    # causing find_python_interpreter() to non-deterministically select
+    # different Python versions across runs.
+    commands = sorted(commands_set, key=lambda p: p.name)
 
     # py and python
     for command in commands:

--- a/kraken-build/src/kraken/common/findpython.py
+++ b/kraken-build/src/kraken/common/findpython.py
@@ -181,8 +181,7 @@ def _get_candidates(
 
     if pyenv_versions and pyenv_versions.is_dir():
         pyenv_dirs = [
-            item for item in pyenv_versions.iterdir()
-            if re.match(r"\d+\.\d+\.\d+$", item.name) and item.is_dir()
+            item for item in pyenv_versions.iterdir() if re.match(r"\d+\.\d+\.\d+$", item.name) and item.is_dir()
         ]
         pyenv_dirs.sort(key=lambda p: Version(p.name))
         for item in pyenv_dirs:

--- a/kraken-build/src/kraken/common/findpython.py
+++ b/kraken-build/src/kraken/common/findpython.py
@@ -135,9 +135,12 @@ def _get_candidates(
     # Sort for deterministic iteration order and correct version ordering.
     # Without this, set iteration order depends on PYTHONHASHSEED (randomised
     # per-process), and lexicographic sort places python3.9 after python3.10.
+    # The full path (str(p)) is used as tiebreaker to ensure deterministic
+    # ordering even when multiple binaries share the same name (e.g. several
+    # "python" or "python3" from different PATH directories).
     def _interpreter_sort_key(p: Path) -> tuple[Version, str]:
         m = re.match(r"python(\d+(?:\.\d+)*)$", p.name)
-        return (Version(m.group(1)), p.name) if m else (Version("0"), p.name)
+        return (Version(m.group(1)), str(p)) if m else (Version("0"), str(p))
 
     commands = sorted(commands_set, key=_interpreter_sort_key)
 

--- a/kraken-build/src/kraken/common/findpython.py
+++ b/kraken-build/src/kraken/common/findpython.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import ClassVar, TypedDict
 
+from packaging.version import Version
 from typing_extensions import NotRequired
 
 logger = logging.getLogger(__name__)
@@ -135,7 +136,11 @@ def _get_candidates(
     # order depends on PYTHONHASHSEED, which is randomised per-process,
     # causing find_python_interpreter() to non-deterministically select
     # different Python versions across runs.
-    commands = sorted(commands_set, key=lambda p: p.name)
+    def _interpreter_sort_key(p: Path) -> Version:
+        m = re.match(r"(?:python|py)([\d.]+)$", p.name)
+        return Version(m.group(1)) if m else Version("0")
+
+    commands = sorted(commands_set, key=_interpreter_sort_key)
 
     # py and python
     for command in commands:
@@ -176,7 +181,11 @@ def _get_candidates(
         pyenv_versions = None
 
     if pyenv_versions and pyenv_versions.is_dir():
-        for item in pyenv_versions.iterdir():
+        pyenv_items = sorted(
+            pyenv_versions.iterdir(),
+            key=lambda p: Version(p.name) if re.match(r"\d+\.\d+\.\d+$", p.name) else Version("0"),
+        )
+        for item in pyenv_items:
             if re.match(r"\d+\.\d+\.\d+$", item.name) and item.is_dir():
                 if os.name == "nt":
                     yield {"path": str(item / "python.exe"), "exact_version": item.name}

--- a/kraken-build/src/kraken/common/findpython.py
+++ b/kraken-build/src/kraken/common/findpython.py
@@ -138,8 +138,10 @@ def _get_candidates(
     # The full path (str(p)) is used as tiebreaker to ensure deterministic
     # ordering even when multiple binaries share the same name (e.g. several
     # "python" or "python3" from different PATH directories).
+    _versioned_python_re = re.compile(r"python(\d+(?:\.\d+)*)$")
+
     def _interpreter_sort_key(p: Path) -> tuple[Version, str]:
-        m = re.match(r"python(\d+(?:\.\d+)*)$", p.name)
+        m = _versioned_python_re.match(p.name)
         return (Version(m.group(1)), str(p)) if m else (Version("0"), str(p))
 
     commands = sorted(commands_set, key=_interpreter_sort_key)

--- a/kraken-build/src/kraken/common/findpython.py
+++ b/kraken-build/src/kraken/common/findpython.py
@@ -132,13 +132,12 @@ def _get_candidates(
             else:
                 commands_set.add(item)
 
-    # Sort for deterministic iteration order. Without this, set iteration
-    # order depends on PYTHONHASHSEED, which is randomised per-process,
-    # causing find_python_interpreter() to non-deterministically select
-    # different Python versions across runs.
-    def _interpreter_sort_key(p: Path) -> Version:
-        m = re.match(r"(?:python|py)([\d.]+)$", p.name)
-        return Version(m.group(1)) if m else Version("0")
+    # Sort for deterministic iteration order and correct version ordering.
+    # Without this, set iteration order depends on PYTHONHASHSEED (randomised
+    # per-process), and lexicographic sort places python3.9 after python3.10.
+    def _interpreter_sort_key(p: Path) -> tuple[Version, str]:
+        m = re.match(r"python(\d+(?:\.\d+)*)$", p.name)
+        return (Version(m.group(1)), p.name) if m else (Version("0"), p.name)
 
     commands = sorted(commands_set, key=_interpreter_sort_key)
 
@@ -181,16 +180,16 @@ def _get_candidates(
         pyenv_versions = None
 
     if pyenv_versions and pyenv_versions.is_dir():
-        pyenv_items = sorted(
-            pyenv_versions.iterdir(),
-            key=lambda p: Version(p.name) if re.match(r"\d+\.\d+\.\d+$", p.name) else Version("0"),
-        )
-        for item in pyenv_items:
-            if re.match(r"\d+\.\d+\.\d+$", item.name) and item.is_dir():
-                if os.name == "nt":
-                    yield {"path": str(item / "python.exe"), "exact_version": item.name}
-                else:
-                    yield {"path": str(item / "bin" / "python"), "exact_version": item.name}
+        pyenv_dirs = [
+            item for item in pyenv_versions.iterdir()
+            if re.match(r"\d+\.\d+\.\d+$", item.name) and item.is_dir()
+        ]
+        pyenv_dirs.sort(key=lambda p: Version(p.name))
+        for item in pyenv_dirs:
+            if os.name == "nt":
+                yield {"path": str(item / "python.exe"), "exact_version": item.name}
+            else:
+                yield {"path": str(item / "bin" / "python"), "exact_version": item.name}
 
     yield {"path": sys.executable, "exact_version": ".".join(map(str, sys.version_info[:3]))}
 

--- a/kraken-build/tests/kraken_common/test_findpython.py
+++ b/kraken-build/tests/kraken_common/test_findpython.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import itertools
 import stat
 from pathlib import Path
 
@@ -24,10 +25,10 @@ def _candidates_from(bin_dir: Path) -> list[str]:
 
 
 class TestGetCandidatesDeterminism:
-    """Verify that _get_candidates yields interpreters in a deterministic order
-    regardless of PYTHONHASHSEED / set-iteration randomness."""
+    """Verify that _get_candidates yields interpreters in a consistent,
+    version-sorted order."""
 
-    def test_candidates_sorted_by_name(self, tmp_path: Path) -> None:
+    def test_candidates_sorted_by_version(self, tmp_path: Path) -> None:
         """pythonX.Y candidates should appear in version-sorted (ascending) order."""
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
@@ -46,3 +47,17 @@ class TestGetCandidatesDeterminism:
             _make_executable(bin_dir / name)
 
         assert _candidates_from(bin_dir) == ["python", "python3", "python3.11", "python3.12"]
+
+    def test_order_stable_across_input_permutations(self, tmp_path: Path) -> None:
+        """Candidate order must be identical regardless of directory iteration order."""
+        names = ["python3.9", "python3.10", "python3.11"]
+        results: list[list[str]] = []
+        for perm in itertools.permutations(names):
+            bin_dir = tmp_path / "bin_" / "_".join(perm)
+            bin_dir.mkdir(parents=True)
+            for name in perm:
+                _make_executable(bin_dir / name)
+            results.append(_candidates_from(bin_dir))
+
+        for result in results[1:]:
+            assert result == results[0], f"order changed across permutations: {results}"

--- a/kraken-build/tests/kraken_common/test_findpython.py
+++ b/kraken-build/tests/kraken_common/test_findpython.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import itertools
 import stat
 from pathlib import Path
+from unittest.mock import patch
 
 from kraken.common.findpython import _get_candidates
 
@@ -48,16 +48,37 @@ class TestGetCandidatesDeterminism:
 
         assert _candidates_from(bin_dir) == ["python", "python3", "python3.11", "python3.12"]
 
-    def test_order_stable_across_input_permutations(self, tmp_path: Path) -> None:
-        """Candidate order must be identical regardless of directory iteration order."""
-        names = ["python3.9", "python3.10", "python3.11"]
-        results: list[list[str]] = []
-        for perm in itertools.permutations(names):
-            bin_dir = tmp_path / "bin_" / "_".join(perm)
-            bin_dir.mkdir(parents=True)
-            for name in perm:
-                _make_executable(bin_dir / name)
-            results.append(_candidates_from(bin_dir))
+    def test_malformed_binary_name_does_not_crash(self, tmp_path: Path) -> None:
+        """Binaries like 'python3.' should not crash the sort key."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        for name in ["python3.", "python3.10", "python3.11"]:
+            _make_executable(bin_dir / name)
 
-        for result in results[1:]:
-            assert result == results[0], f"order changed across permutations: {results}"
+        result = _candidates_from(bin_dir)
+        assert "python3.10" in result
+        assert "python3.11" in result
+
+    def test_pyenv_versions_sorted_by_version(self, tmp_path: Path) -> None:
+        """Pyenv version directories should be yielded in version-sorted order."""
+        pyenv_root = tmp_path / "pyenv"
+        versions_dir = pyenv_root / "versions"
+        versions_dir.mkdir(parents=True)
+
+        for version in ["3.10.5", "3.9.1", "3.12.0", "3.11.3"]:
+            ver_dir = versions_dir / version
+            (ver_dir / "bin").mkdir(parents=True)
+            _make_executable(ver_dir / "bin" / "python")
+
+        # Use an empty PATH bin dir so only pyenv candidates appear
+        empty_bin = tmp_path / "empty_bin"
+        empty_bin.mkdir()
+
+        with patch.dict("os.environ", {"PYENV": str(pyenv_root)}):
+            candidates = [
+                c["exact_version"]
+                for c in _get_candidates(path_list=[str(empty_bin)], check_pyenv=True)
+                if "exact_version" in c and str(versions_dir) in c["path"]
+            ]
+
+        assert candidates == ["3.9.1", "3.10.5", "3.11.3", "3.12.0"]

--- a/kraken-build/tests/kraken_common/test_findpython.py
+++ b/kraken-build/tests/kraken_common/test_findpython.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import os
 import stat
 from pathlib import Path
-from unittest.mock import patch
 
 from kraken.common.findpython import _get_candidates
 
@@ -29,30 +27,16 @@ class TestGetCandidatesDeterminism:
     """Verify that _get_candidates yields interpreters in a deterministic order
     regardless of PYTHONHASHSEED / set-iteration randomness."""
 
-    def test_candidates_are_deterministic_across_seeds(self, tmp_path: Path) -> None:
-        """The candidate order must not depend on the hash seed."""
-        bin_dir = tmp_path / "bin"
-        bin_dir.mkdir()
-        for name in ["python3.13", "python3.10", "python3.12", "python3.11"]:
-            _make_executable(bin_dir / name)
-
-        results: list[list[str]] = []
-        for seed in ["0", "1", "42", "99999"]:
-            with patch.dict(os.environ, {"PYTHONHASHSEED": seed}):
-                results.append(_candidates_from(bin_dir))
-
-        # All runs must produce the same ordering.
-        for result in results[1:]:
-            assert result == results[0], f"candidate order changed between hash seeds: {results}"
-
     def test_candidates_sorted_by_name(self, tmp_path: Path) -> None:
-        """pythonX.Y candidates should appear in sorted (ascending) name order."""
+        """pythonX.Y candidates should appear in version-sorted (ascending) order."""
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
-        for name in ["python3.13", "python3.10", "python3.12", "python3.11"]:
+        for name in ["python3.13", "python3.9", "python3.10", "python3.12", "python3.11"]:
             _make_executable(bin_dir / name)
 
-        assert _candidates_from(bin_dir) == ["python3.10", "python3.11", "python3.12", "python3.13"]
+        assert _candidates_from(bin_dir) == [
+            "python3.9", "python3.10", "python3.11", "python3.12", "python3.13"
+        ]
 
     def test_category_order_preserved(self, tmp_path: Path) -> None:
         """Generic names should appear before versioned names (py < pythonX < pythonX.Y)."""

--- a/kraken-build/tests/kraken_common/test_findpython.py
+++ b/kraken-build/tests/kraken_common/test_findpython.py
@@ -80,3 +80,31 @@ class TestGetCandidatesDeterminism:
             ]
 
         assert candidates == ["3.9.1", "3.10.5", "3.11.3", "3.12.0"]
+
+    def test_same_name_across_directories_sorted_by_path(self, tmp_path: Path) -> None:
+        """Multiple 'python' binaries from different PATH directories must be
+        ordered deterministically by full path, not just by filename.
+
+        Without using str(p) as the sort tiebreaker, all these binaries would
+        share the sort key (Version("0"), "python") and their relative order
+        would depend on set iteration — which is randomised per-process via
+        PYTHONHASHSEED. This caused krakenw to pick different interpreters
+        across runs, producing oscillating lock files."""
+        # Create three directories with identically-named "python" binaries,
+        # using names that sort differently lexicographically vs by insertion.
+        dir_a = tmp_path / "aaa"
+        dir_b = tmp_path / "bbb"
+        dir_c = tmp_path / "ccc"
+        for d in [dir_a, dir_b, dir_c]:
+            d.mkdir()
+            _make_executable(d / "python")
+
+        paths = [
+            Path(c["path"])
+            for c in _get_candidates(path_list=[str(dir_c), str(dir_a), str(dir_b)], check_pyenv=False)
+            if Path(c["path"]).name == "python" and Path(c["path"]).parent in (dir_a, dir_b, dir_c)
+        ]
+
+        # Must be sorted by full path (aaa < bbb < ccc), regardless of the
+        # order the directories were listed in path_list.
+        assert paths == [dir_a / "python", dir_b / "python", dir_c / "python"]

--- a/kraken-build/tests/kraken_common/test_findpython.py
+++ b/kraken-build/tests/kraken_common/test_findpython.py
@@ -1,0 +1,64 @@
+"""Tests for kraken.common.findpython — Python interpreter discovery."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+from kraken.common.findpython import _get_candidates
+
+
+def _make_executable(path: Path) -> None:
+    path.touch()
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _candidates_from(bin_dir: Path) -> list[str]:
+    """Return candidate names from the given directory, excluding the
+    sys.executable fallback that _get_candidates always appends."""
+    return [
+        Path(c["path"]).name
+        for c in _get_candidates(path_list=[str(bin_dir)], check_pyenv=False)
+        if Path(c["path"]).parent == bin_dir
+    ]
+
+
+class TestGetCandidatesDeterminism:
+    """Verify that _get_candidates yields interpreters in a deterministic order
+    regardless of PYTHONHASHSEED / set-iteration randomness."""
+
+    def test_candidates_are_deterministic_across_seeds(self, tmp_path: Path) -> None:
+        """The candidate order must not depend on the hash seed."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        for name in ["python3.13", "python3.10", "python3.12", "python3.11"]:
+            _make_executable(bin_dir / name)
+
+        results: list[list[str]] = []
+        for seed in ["0", "1", "42", "99999"]:
+            with patch.dict(os.environ, {"PYTHONHASHSEED": seed}):
+                results.append(_candidates_from(bin_dir))
+
+        # All runs must produce the same ordering.
+        for result in results[1:]:
+            assert result == results[0], f"candidate order changed between hash seeds: {results}"
+
+    def test_candidates_sorted_by_name(self, tmp_path: Path) -> None:
+        """pythonX.Y candidates should appear in sorted (ascending) name order."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        for name in ["python3.13", "python3.10", "python3.12", "python3.11"]:
+            _make_executable(bin_dir / name)
+
+        assert _candidates_from(bin_dir) == ["python3.10", "python3.11", "python3.12", "python3.13"]
+
+    def test_category_order_preserved(self, tmp_path: Path) -> None:
+        """Generic names should appear before versioned names (py < pythonX < pythonX.Y)."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        for name in ["python3.12", "python3", "python", "python3.11"]:
+            _make_executable(bin_dir / name)
+
+        assert _candidates_from(bin_dir) == ["python", "python3", "python3.11", "python3.12"]

--- a/kraken-build/tests/kraken_common/test_findpython.py
+++ b/kraken-build/tests/kraken_common/test_findpython.py
@@ -35,9 +35,7 @@ class TestGetCandidatesDeterminism:
         for name in ["python3.13", "python3.9", "python3.10", "python3.12", "python3.11"]:
             _make_executable(bin_dir / name)
 
-        assert _candidates_from(bin_dir) == [
-            "python3.9", "python3.10", "python3.11", "python3.12", "python3.13"
-        ]
+        assert _candidates_from(bin_dir) == ["python3.9", "python3.10", "python3.11", "python3.12", "python3.13"]
 
     def test_category_order_preserved(self, tmp_path: Path) -> None:
         """Generic names should appear before versioned names (py < pythonX < pythonX.Y)."""


### PR DESCRIPTION
## Summary

`_get_candidates()` collects Python binaries into a `set[Path]` and iterates over it to yield candidates. Python set iteration order depends on `PYTHONHASHSEED`, which is randomised per-process by default. This causes `find_python_interpreter()` to non-deterministically select different Python versions across runs when multiple versions satisfy the constraint.

## Problem

This matters because `.kraken.lock` is a flat format (no per-version forks). Packages guarded by `python_version` markers (e.g. `backports-tarfile; python_version < "3.12"`) are included or excluded depending on which interpreter was chosen, producing non-reproducible lock files and endless add/remove oscillation in CI-driven lock-file maintenance (observed on multiple repos with 20+ consecutive flip-flop commits).

## Fix

Sort the `set[Path]` by filename before iterating. This ensures deterministic, version-ascending order (`python3.10` < `python3.11` < `python3.12`), so `find_python_interpreter()` always picks the lowest matching version.

This follows what is done for example with uv: https://docs.astral.sh/uv/concepts/python-versions/#discovery-of-python-versions
