### PR TITLE
fix: address PR #408 review issues

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,10 +1,4 @@
 [[entries]]
-id = "a1ce3786-5ead-4bf0-8765-ac2f15e9d0e6"
-type = "fix"
-description = "Remove default argument that caused deprecation warning to always be triggered"
-author = "scott@stevenson.io"
-
-[[entries]]
 id = "fc8e7ccd-f080-4f1d-a987-f92c4776388d"
 type = "breaking change"
 description = "Drop support for Python projects that use Poetry, PDM or Slap"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 /result
 .DS_Store
 .direnv/
+.worktrees/

--- a/kraken-build/src/kraken/std/python/pyproject.py
+++ b/kraken-build/src/kraken/std/python/pyproject.py
@@ -14,11 +14,9 @@ logger = logging.getLogger(__name__)
 
 class _PackageIndexPriority(str, Enum):
     """
-    The concept of package index priority is inherit from prior support for Poetry, which has a very granular
-    representation of priorities for indices, so we inherit that. The priority should to be interpreted in the spirit
-    of its definition in other tools.
-
-    https://python-poetry.org/docs/repositories/#project-configuration
+    Represents the priority of a package index. Used by the Uv integration to determine which index takes
+    precedence when resolving packages. The priority should be interpreted in the spirit of its definition
+    in the underlying tool.
     """
 
     # in decreasing order of priority

--- a/kraken-build/src/kraken/std/python/settings.py
+++ b/kraken-build/src/kraken/std/python/settings.py
@@ -204,7 +204,7 @@ def python_settings(
         settings.lint_enforced_directories = dirs
 
     if always_use_managed_env is not None:
-        settings.always_use_managed_env = True
+        settings.always_use_managed_env = always_use_managed_env
 
     if skip_install_if_venv_exists is not None:
         settings.skip_install_if_venv_exists = skip_install_if_venv_exists


### PR DESCRIPTION
## Summary

- Fix `always_use_managed_env` assignment bug in `python_settings()`: was hardcoded to `True` instead of using the parameter value
- Remove stale Poetry reference and link from `_PackageIndexPriority` docstring; rewrite it to describe the priorities generically for the Uv integration
- Remove duplicate changelog entry `a1ce3786` from `_unreleased.toml` (already released in `0.50.5`)

## Test plan

- [ ] Verify `python_settings(always_use_managed_env=False)` now correctly sets the setting to `False`
- [ ] Confirm `_PackageIndexPriority` docstring no longer references Poetry or its docs URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)