### PR TITLE
Don't install all packages when using uv workspaces

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "f015578f-97e9-4a72-9998-cce678b1aba4"
+type = "improvement"
+description = "Don't install all uv workspaces"
+author = "antoine.broyelle@helsing.ai"

--- a/kraken-build/src/kraken/std/python/buildsystem/uv.py
+++ b/kraken-build/src/kraken/std/python/buildsystem/uv.py
@@ -350,7 +350,7 @@ class UvManagedEnvironment(ManagedEnvironment):
 
     def install(self, settings: PythonSettings) -> None:
         # --locked is used only when uv.lock is present
-        cmd = ["uv", "sync", "--all-packages"]
+        cmd = ["uv", "sync"]
         if (self.project_directory / "uv.lock").is_file():
             cmd.append("--locked")
 


### PR DESCRIPTION
Kraken shouldn't enforce that when using uv workspaces all packages must be installed inside the single venv. The concept of workspace in Kraken is quite different than the one in uv.